### PR TITLE
SpringCloudCommandRouter should have the ability to configure the contextRoot from Metadata

### DIFF
--- a/springcloud-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/springcloud/DistributedCommandBusProperties.java
+++ b/springcloud-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/springcloud/DistributedCommandBusProperties.java
@@ -121,11 +121,11 @@ public class DistributedCommandBusProperties {
          */
         private String fallbackUrl = "/message-routing-information";
 
-		/**
-		 * The optional name of the spring cloud service instance metdata property,
-		 * that does contain the contextroot path of the service.
-		 */
-		private String contextRootMetadataPropertyname;
+        /**
+         * The optional name of the spring cloud service instance metdata property,
+         * that does contain the contextroot path of the service.
+         */
+        private String contextRootMetadataPropertyname;
 
         /**
          * Indicates whether to fall back to HTTP GET when retrieving Instance Meta Data from the Discovery Server
@@ -167,20 +167,20 @@ public class DistributedCommandBusProperties {
             this.fallbackUrl = fallbackUrl;
         }
 
-		/**
-		 * @return the optional name of the spring cloud service instance metdata property,
-		 *          that does contain the contextroot path of the service.
-		 */
-		public String getContextRootMetadataPropertyname() {
-			return contextRootMetadataPropertyname;
-		}
+        /**
+         * @return the optional name of the spring cloud service instance metdata property,
+         * that does contain the contextroot path of the service.
+         */
+        public String getContextRootMetadataPropertyname() {
+            return contextRootMetadataPropertyname;
+        }
 
-		/**
-		 * @param contextRootMetadataPropertyname the optional name of the spring cloud service instance metdata property,
-		 *                                        that does contain the contextroot path of the service.
-		 */
-		public void setContextRootMetadataPropertyname(String contextRootMetadataPropertyname) {
-			this.contextRootMetadataPropertyname = contextRootMetadataPropertyname;
-		}
+        /**
+         * @param contextRootMetadataPropertyname the optional name of the spring cloud service instance metdata property,
+         *                                        that does contain the contextroot path of the service.
+         */
+        public void setContextRootMetadataPropertyname(String contextRootMetadataPropertyname) {
+            this.contextRootMetadataPropertyname = contextRootMetadataPropertyname;
+        }
     }
 }

--- a/springcloud-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/springcloud/DistributedCommandBusProperties.java
+++ b/springcloud-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/springcloud/DistributedCommandBusProperties.java
@@ -121,6 +121,12 @@ public class DistributedCommandBusProperties {
          */
         private String fallbackUrl = "/message-routing-information";
 
+		/**
+		 * The optional name of the spring cloud service instance metdata property,
+		 * that does contain the contextroot path of the service.
+		 */
+		private String contextRootMetadataPropertyname;
+
         /**
          * Indicates whether to fall back to HTTP GET when retrieving Instance Meta Data from the Discovery Server
          * fails.
@@ -160,5 +166,21 @@ public class DistributedCommandBusProperties {
         public void setFallbackUrl(String fallbackUrl) {
             this.fallbackUrl = fallbackUrl;
         }
+
+		/**
+		 * @return the optional name of the spring cloud service instance metdata property,
+		 *          that does contain the contextroot path of the service.
+		 */
+		public String getContextRootMetadataPropertyname() {
+			return contextRootMetadataPropertyname;
+		}
+
+		/**
+		 * @param contextRootMetadataPropertyname the optional name of the spring cloud service instance metdata property,
+		 *                                        that does contain the contextroot path of the service.
+		 */
+		public void setContextRootMetadataPropertyname(String contextRootMetadataPropertyname) {
+			this.contextRootMetadataPropertyname = contextRootMetadataPropertyname;
+		}
     }
 }

--- a/springcloud-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/springcloud/DistributedCommandBusProperties.java
+++ b/springcloud-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/springcloud/DistributedCommandBusProperties.java
@@ -125,7 +125,7 @@ public class DistributedCommandBusProperties {
          * The optional name of the spring cloud service instance metdata property,
          * that does contain the contextroot path of the service.
          */
-        private String contextRootMetadataPropertyname;
+        private String contextRootMetadataPropertyName;
 
         /**
          * Indicates whether to fall back to HTTP GET when retrieving Instance Meta Data from the Discovery Server
@@ -168,19 +168,22 @@ public class DistributedCommandBusProperties {
         }
 
         /**
-         * @return the optional name of the spring cloud service instance metdata property,
+         * Returns the optional name of the spring cloud service instance metadata property,
+         * that does contain the contextroot path of the service.
+         *
+         * @return the optional name of the spring cloud service instance metadata property,
          * that does contain the contextroot path of the service.
          */
-        public String getContextRootMetadataPropertyname() {
-            return contextRootMetadataPropertyname;
+        public String getContextRootMetadataPropertyName() {
+            return contextRootMetadataPropertyName;
         }
 
         /**
-         * @param contextRootMetadataPropertyname the optional name of the spring cloud service instance metdata property,
+         * @param contextRootMetadataPropertyName the optional name of the spring cloud service instance metdata property,
          *                                        that does contain the contextroot path of the service.
          */
-        public void setContextRootMetadataPropertyname(String contextRootMetadataPropertyname) {
-            this.contextRootMetadataPropertyname = contextRootMetadataPropertyname;
+        public void setContextRootMetadataPropertyName(String contextRootMetadataPropertyName) {
+            this.contextRootMetadataPropertyName = contextRootMetadataPropertyName;
         }
     }
 }

--- a/springcloud-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/springcloud/autoconfig/SpringCloudAutoConfiguration.java
+++ b/springcloud-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/springcloud/autoconfig/SpringCloudAutoConfiguration.java
@@ -97,6 +97,8 @@ public class SpringCloudAutoConfiguration {
                                                  .restTemplate(restTemplate)
                                                  .messageRoutingInformationEndpoint(properties.getSpringCloud()
                                                                                               .getFallbackUrl())
+                                                 .contextRootMetadataPropertyname(properties.getSpringCloud()
+                                                                                            .getContextRootMetadataPropertyname())
                                                  .build();
     }
 

--- a/springcloud-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/springcloud/autoconfig/SpringCloudAutoConfiguration.java
+++ b/springcloud-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/springcloud/autoconfig/SpringCloudAutoConfiguration.java
@@ -98,7 +98,7 @@ public class SpringCloudAutoConfiguration {
                                                  .messageRoutingInformationEndpoint(properties.getSpringCloud()
                                                                                               .getFallbackUrl())
                                                  .contextRootMetadataPropertyname(properties.getSpringCloud()
-                                                                                            .getContextRootMetadataPropertyname())
+                                                                                            .getContextRootMetadataPropertyName())
                                                  .build();
     }
 

--- a/springcloud/src/main/java/org/axonframework/extensions/springcloud/commandhandling/SpringCloudCommandRouter.java
+++ b/springcloud/src/main/java/org/axonframework/extensions/springcloud/commandhandling/SpringCloudCommandRouter.java
@@ -310,10 +310,11 @@ public class SpringCloudCommandRouter implements CommandRouter {
 
     private Member buildLocalMember(ServiceInstance localServiceInstance) {
         String localServiceId = localServiceInstance.getServiceId();
+        URI serviceWithContextRootUri = buildRemoteUriWithContextRoot(localServiceInstance);
         URI emptyEndpoint = null;
         //noinspection ConstantConditions | added null variable for clarity
         return registered
-                ? new SimpleMember<>(buildSimpleMemberName(localServiceId, localServiceInstance.getUri()),
+                ? new SimpleMember<>(buildSimpleMemberName(localServiceId, serviceWithContextRootUri),
                                      localServiceInstance.getUri(),
                                      SimpleMember.LOCAL_MEMBER,
                                      this::suspect)

--- a/springcloud/src/main/java/org/axonframework/extensions/springcloud/commandhandling/SpringCloudCommandRouter.java
+++ b/springcloud/src/main/java/org/axonframework/extensions/springcloud/commandhandling/SpringCloudCommandRouter.java
@@ -324,9 +324,9 @@ public class SpringCloudCommandRouter implements CommandRouter {
     }
 
     private Member buildRemoteMember(ServiceInstance remoteServiceInstance) {
-		URI serviceWithContextRootUri = buildRemoteUriWithContextRoot(remoteServiceInstance);
+        URI serviceWithContextRootUri = buildRemoteUriWithContextRoot(remoteServiceInstance);
 
-		return new SimpleMember<>(buildSimpleMemberName(remoteServiceInstance.getServiceId(), serviceWithContextRootUri),
+        return new SimpleMember<>(buildSimpleMemberName(remoteServiceInstance.getServiceId(), serviceWithContextRootUri),
                                   serviceWithContextRootUri,
                                   SimpleMember.REMOTE_MEMBER,
                                   this::suspect);

--- a/springcloud/src/main/java/org/axonframework/extensions/springcloud/commandhandling/SpringCloudCommandRouter.java
+++ b/springcloud/src/main/java/org/axonframework/extensions/springcloud/commandhandling/SpringCloudCommandRouter.java
@@ -94,6 +94,7 @@ public class SpringCloudCommandRouter implements CommandRouter {
         routingStrategy = builder.routingStrategy;
         serviceInstanceFilter = builder.serviceInstanceFilter;
         consistentHashChangeListener = builder.consistentHashChangeListener;
+        contextRootMetadataPropertyname = builder.contextRootMetadataPropertyname;
     }
 
     /**
@@ -408,6 +409,7 @@ public class SpringCloudCommandRouter implements CommandRouter {
         private Predicate<ServiceInstance> serviceInstanceFilter =
                 SpringCloudCommandRouter::serviceInstanceMetadataContainsMessageRoutingInformation;
         private ConsistentHashChangeListener consistentHashChangeListener = ConsistentHashChangeListener.noOp();
+        private String contextRootMetadataPropertyname;
 
         /**
          * Sets the {@link DiscoveryClient} used to discovery and notify other nodes. Used to update its own membership
@@ -478,6 +480,16 @@ public class SpringCloudCommandRouter implements CommandRouter {
         public Builder consistentHashChangeListener(ConsistentHashChangeListener consistentHashChangeListener) {
             assertNonNull(consistentHashChangeListener, "ConsistentHashChangeListener may not be null");
             this.consistentHashChangeListener = consistentHashChangeListener;
+            return this;
+        }
+
+        /**
+         * @param contextRootMetadataPropertyname the optional name of the spring cloud service instance metdata property,
+         *                                        that does contain the contextroot path of the service.
+         * @return the current Builder instance, for fluent interfacing
+         */
+        public Builder contextRootMetadataPropertyname(String contextRootMetadataPropertyname) {
+            this.contextRootMetadataPropertyname = contextRootMetadataPropertyname;
             return this;
         }
 

--- a/springcloud/src/main/java/org/axonframework/extensions/springcloud/commandhandling/SpringCloudHttpBackupCommandRouter.java
+++ b/springcloud/src/main/java/org/axonframework/extensions/springcloud/commandhandling/SpringCloudHttpBackupCommandRouter.java
@@ -173,7 +173,8 @@ public class SpringCloudHttpBackupCommandRouter extends SpringCloudCommandRouter
 
     private static URI buildURIForPath(URI uri, String appendToPath) {
         return UriComponentsBuilder.fromUri(uri)
-                                   .path(uri.getPath() + appendToPath)
+                                   // .path() already appends to an existing path in uri, so just enter the appendToPath here
+                                   .path(appendToPath)
                                    .build()
                                    .toUri();
     }

--- a/springcloud/src/main/java/org/axonframework/extensions/springcloud/commandhandling/SpringCloudHttpBackupCommandRouter.java
+++ b/springcloud/src/main/java/org/axonframework/extensions/springcloud/commandhandling/SpringCloudHttpBackupCommandRouter.java
@@ -260,6 +260,16 @@ public class SpringCloudHttpBackupCommandRouter extends SpringCloudCommandRouter
         }
 
         /**
+         * @param contextRootMetadataPropertyname the optional name of the spring cloud service instance metdata property,
+         *                                        that does contain the contextroot path of the service.
+         * @return the current Builder instance, for fluent interfacing
+         */
+        public Builder contextRootMetadataPropertyname(String contextRootMetadataPropertyname) {
+            super.contextRootMetadataPropertyname(contextRootMetadataPropertyname);
+            return this;
+        }
+
+        /**
          * Initializes a {@link SpringCloudHttpBackupCommandRouter} as specified through this Builder.
          *
          * @return a {@link SpringCloudHttpBackupCommandRouter} as specified through this Builder

--- a/springcloud/src/test/java/org/axonframework/extensions/springcloud/commandhandling/SpringCloudCommandRouterTest.java
+++ b/springcloud/src/test/java/org/axonframework/extensions/springcloud/commandhandling/SpringCloudCommandRouterTest.java
@@ -53,6 +53,7 @@ public class SpringCloudCommandRouterTest {
     private static final String LOAD_FACTOR_KEY = "loadFactor";
     private static final String SERIALIZED_COMMAND_FILTER_KEY = "serializedCommandFilter";
     private static final String SERIALIZED_COMMAND_FILTER_CLASS_NAME_KEY = "serializedCommandFilterClassName";
+    private static final String CONTEXT_ROOT_KEY = "contextRoot";
 
     private static final int LOAD_FACTOR = 1;
     private static final CommandMessage<Object> TEST_COMMAND = GenericCommandMessage.asCommandMessage("testCommand");

--- a/springcloud/src/test/java/org/axonframework/extensions/springcloud/commandhandling/SpringCloudCommandRouterTest.java
+++ b/springcloud/src/test/java/org/axonframework/extensions/springcloud/commandhandling/SpringCloudCommandRouterTest.java
@@ -563,4 +563,30 @@ public class SpringCloudCommandRouterTest {
                         })
                         .collect(toList());
     }
+
+    @Test
+    public void testBuildMemberWithContextRootPropertynameCreatesAnUriWithContextRoot() {
+
+        testSubject = SpringCloudCommandRouter.builder()
+                .discoveryClient(discoveryClient)
+                .localServiceInstance(localServiceInstance)
+                .routingStrategy(routingStrategy)
+                .serviceInstanceFilter(serviceInstance -> true)
+                .consistentHashChangeListener(ConsistentHashChangeListener.noOp())
+                .contextRootMetadataPropertyname(CONTEXT_ROOT_KEY)
+                .build();
+
+        serviceInstanceMetadata.put(CONTEXT_ROOT_KEY, "/contextRootPath");
+
+        ServiceInstance remoteInstance = mock(ServiceInstance.class);
+        when(remoteInstance.getServiceId()).thenReturn(SERVICE_INSTANCE_ID);
+        when(remoteInstance.getUri()).thenReturn(URI.create("remote"));
+        when(remoteInstance.getMetadata()).thenReturn(serviceInstanceMetadata);
+
+        Member memberWithContextRootUri = testSubject.buildMember(remoteInstance);
+
+        Optional<URI> connectionEndpoint = memberWithContextRootUri.getConnectionEndpoint(URI.class);
+        assertTrue(connectionEndpoint.isPresent());
+        assertEquals(connectionEndpoint.get().toString(), "remote/contextRootPath");
+    }
 }

--- a/springcloud/src/test/java/org/axonframework/extensions/springcloud/commandhandling/SpringCloudCommandRouterTest.java
+++ b/springcloud/src/test/java/org/axonframework/extensions/springcloud/commandhandling/SpringCloudCommandRouterTest.java
@@ -617,7 +617,7 @@ public class SpringCloudCommandRouterTest {
                 UriComponentsBuilder.fromUriString("remote/contextRootPath")
                         .build().toUri());
 
-        Member memberWithContextRootUri = testSubject.buildMember(localServiceInstance);
+        Member memberWithContextRootUri = testSubject.buildMember(localInstance);
 
         Optional<URI> connectionEndpoint = memberWithContextRootUri.getConnectionEndpoint(URI.class);
         assertTrue(connectionEndpoint.isPresent());

--- a/springcloud/src/test/java/org/axonframework/extensions/springcloud/commandhandling/SpringCloudHttpBackupCommandRouterTest.java
+++ b/springcloud/src/test/java/org/axonframework/extensions/springcloud/commandhandling/SpringCloudHttpBackupCommandRouterTest.java
@@ -102,8 +102,9 @@ public class SpringCloudHttpBackupCommandRouterTest {
                                                         .routingStrategy(routingStrategy)
                                                         .restTemplate(restTemplate)
                                                         .messageRoutingInformationEndpoint(
-                                                                messageRoutingInformationEndpoint
-                                                        ).build();
+                                                                messageRoutingInformationEndpoint)
+                                                        .contextRootMetadataPropertyname(contextRootMetadataPropertyname)
+                                                        .build();
     }
 
     @Test

--- a/springcloud/src/test/java/org/axonframework/extensions/springcloud/commandhandling/SpringCloudHttpBackupCommandRouterTest.java
+++ b/springcloud/src/test/java/org/axonframework/extensions/springcloud/commandhandling/SpringCloudHttpBackupCommandRouterTest.java
@@ -43,6 +43,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 import java.net.URI;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.junit.Assert.*;
@@ -271,9 +272,9 @@ public class SpringCloudHttpBackupCommandRouterTest {
         ServiceInstance remoteInstance = mock(ServiceInstance.class);
         when(remoteInstance.getServiceId()).thenReturn(SERVICE_INSTANCE_ID);
         when(remoteInstance.getUri()).thenReturn(testRemoteUri);
-        when(remoteInstance.getMetadata()).thenReturn(new HashMap<String, String>() {{
-            put(contextRootMetadataPropertyname, "/contextRootPath");
-        }});
+        Map<String, String> metadataWithContextRootPath = new HashMap<>();
+        metadataWithContextRootPath.put(contextRootMetadataPropertyname, "/contextRootPath");
+        when(remoteInstance.getMetadata()).thenReturn(metadataWithContextRootPath);
 
         when(discoveryClient.getServices()).thenReturn(ImmutableList.of(SERVICE_INSTANCE_ID));
         when(discoveryClient.getInstances(SERVICE_INSTANCE_ID))


### PR DESCRIPTION
This is my proposed PR regard the issue:
https://github.com/AxonFramework/AxonFramework/issues/1051

With this PR, you are able to define a contextroot for e.g. the "message-routing-information" endpoint by using the ServiceInstance-Metadata.