### PR TITLE
[#9] Spring Cloud Kubernetes produces NullPointerException for ServiceInstance#getMetaData

### DIFF
--- a/springcloud/src/main/java/org/axonframework/extensions/springcloud/commandhandling/SpringCloudCommandRouter.java
+++ b/springcloud/src/main/java/org/axonframework/extensions/springcloud/commandhandling/SpringCloudCommandRouter.java
@@ -148,12 +148,14 @@ public class SpringCloudCommandRouter implements CommandRouter {
     @Override
     public void updateMembership(int loadFactor, CommandMessageFilter commandFilter) {
         Map<String, String> localServiceInstanceMetadata = localServiceInstance.getMetadata();
-        localServiceInstanceMetadata.put(LOAD_FACTOR, Integer.toString(loadFactor));
-        SerializedObject<String> serializedCommandFilter = serializer.serialize(commandFilter, String.class);
-        localServiceInstanceMetadata.put(SERIALIZED_COMMAND_FILTER, serializedCommandFilter.getData());
-        localServiceInstanceMetadata.put(
-                SERIALIZED_COMMAND_FILTER_CLASS_NAME, serializedCommandFilter.getType().getName()
-        );
+        if (localServiceInstanceMetadata != null) {
+        	localServiceInstanceMetadata.put(LOAD_FACTOR, Integer.toString(loadFactor));
+        	SerializedObject<String> serializedCommandFilter = serializer.serialize(commandFilter, String.class);
+        	localServiceInstanceMetadata.put(SERIALIZED_COMMAND_FILTER, serializedCommandFilter.getData());
+        	localServiceInstanceMetadata.put(
+        			SERIALIZED_COMMAND_FILTER_CLASS_NAME, serializedCommandFilter.getType().getName()
+        			);
+        }
 
         updateMembershipForServiceInstance(localServiceInstance, atomicConsistentHash)
                 .ifPresent(consistentHashChangeListener::onConsistentHashChanged);

--- a/springcloud/src/main/java/org/axonframework/extensions/springcloud/commandhandling/SpringCloudCommandRouter.java
+++ b/springcloud/src/main/java/org/axonframework/extensions/springcloud/commandhandling/SpringCloudCommandRouter.java
@@ -135,13 +135,10 @@ public class SpringCloudCommandRouter implements CommandRouter {
      */
     public static boolean serviceInstanceMetadataContainsMessageRoutingInformation(ServiceInstance serviceInstance) {
         Map<String, String> serviceInstanceMetadata = serviceInstance.getMetadata();
-        if (serviceInstanceMetadata == null) {
-            return false;
-        } else {
-            return serviceInstanceMetadata.containsKey(LOAD_FACTOR) &&
-                    serviceInstanceMetadata.containsKey(SERIALIZED_COMMAND_FILTER) &&
-                    serviceInstanceMetadata.containsKey(SERIALIZED_COMMAND_FILTER_CLASS_NAME);
-        }
+        return serviceInstanceMetadata != null && 
+                serviceInstanceMetadata.containsKey(LOAD_FACTOR) &&
+                serviceInstanceMetadata.containsKey(SERIALIZED_COMMAND_FILTER) &&
+                serviceInstanceMetadata.containsKey(SERIALIZED_COMMAND_FILTER_CLASS_NAME);
     }
 
     @Override

--- a/springcloud/src/main/java/org/axonframework/extensions/springcloud/commandhandling/SpringCloudCommandRouter.java
+++ b/springcloud/src/main/java/org/axonframework/extensions/springcloud/commandhandling/SpringCloudCommandRouter.java
@@ -149,12 +149,12 @@ public class SpringCloudCommandRouter implements CommandRouter {
     public void updateMembership(int loadFactor, CommandMessageFilter commandFilter) {
         Map<String, String> localServiceInstanceMetadata = localServiceInstance.getMetadata();
         if (localServiceInstanceMetadata != null) {
-        	localServiceInstanceMetadata.put(LOAD_FACTOR, Integer.toString(loadFactor));
-        	SerializedObject<String> serializedCommandFilter = serializer.serialize(commandFilter, String.class);
-        	localServiceInstanceMetadata.put(SERIALIZED_COMMAND_FILTER, serializedCommandFilter.getData());
-        	localServiceInstanceMetadata.put(
-        			SERIALIZED_COMMAND_FILTER_CLASS_NAME, serializedCommandFilter.getType().getName()
-        			);
+            localServiceInstanceMetadata.put(LOAD_FACTOR, Integer.toString(loadFactor));
+            SerializedObject<String> serializedCommandFilter = serializer.serialize(commandFilter, String.class);
+            localServiceInstanceMetadata.put(SERIALIZED_COMMAND_FILTER, serializedCommandFilter.getData());
+            localServiceInstanceMetadata.put(
+                SERIALIZED_COMMAND_FILTER_CLASS_NAME, serializedCommandFilter.getType().getName()
+            );
         }
 
         updateMembershipForServiceInstance(localServiceInstance, atomicConsistentHash)

--- a/springcloud/src/main/java/org/axonframework/extensions/springcloud/commandhandling/SpringCloudCommandRouter.java
+++ b/springcloud/src/main/java/org/axonframework/extensions/springcloud/commandhandling/SpringCloudCommandRouter.java
@@ -135,9 +135,13 @@ public class SpringCloudCommandRouter implements CommandRouter {
      */
     public static boolean serviceInstanceMetadataContainsMessageRoutingInformation(ServiceInstance serviceInstance) {
         Map<String, String> serviceInstanceMetadata = serviceInstance.getMetadata();
-        return serviceInstanceMetadata.containsKey(LOAD_FACTOR) &&
-                serviceInstanceMetadata.containsKey(SERIALIZED_COMMAND_FILTER) &&
-                serviceInstanceMetadata.containsKey(SERIALIZED_COMMAND_FILTER_CLASS_NAME);
+        if (serviceInstanceMetadata == null) {
+            return false;
+        } else {
+            return serviceInstanceMetadata.containsKey(LOAD_FACTOR) &&
+                    serviceInstanceMetadata.containsKey(SERIALIZED_COMMAND_FILTER) &&
+                    serviceInstanceMetadata.containsKey(SERIALIZED_COMMAND_FILTER_CLASS_NAME);
+        }
     }
 
     @Override

--- a/springcloud/src/test/java/org/axonframework/extensions/springcloud/commandhandling/SpringCloudCommandRouterTest.java
+++ b/springcloud/src/test/java/org/axonframework/extensions/springcloud/commandhandling/SpringCloudCommandRouterTest.java
@@ -566,7 +566,6 @@ public class SpringCloudCommandRouterTest {
                                        .serviceInstanceFilter(serviceInstance -> true)
                                        .consistentHashChangeListener(consistentHashChangeListener)
                                        .build();
-        //router.updateMembership(LOAD_FACTOR, COMMAND_NAME_FILTER);
         return router;
     }
 

--- a/springcloud/src/test/java/org/axonframework/extensions/springcloud/commandhandling/SpringCloudCommandRouterTest.java
+++ b/springcloud/src/test/java/org/axonframework/extensions/springcloud/commandhandling/SpringCloudCommandRouterTest.java
@@ -177,12 +177,7 @@ public class SpringCloudCommandRouterTest {
         CommandMessageFilter commandNameFilter = new CommandNameFilter(String.class.getName());
         testSubject.updateMembership(LOAD_FACTOR, commandNameFilter);
 
-        verify(consistentHashChangeListener, never()).onConsistentHashChanged(argThat(item -> item.getMembers()
-                                                                                         .stream()
-                                                                                         .map(Member::name)
-                                                                                         .anyMatch(memberName -> memberName
-                                                                                                 .contains(
-                                                                                                         SERVICE_INSTANCE_ID))));
+        verifyZeroInteractions(consistentHashChangeListener);
     }
 
     @Test

--- a/springcloud/src/test/java/org/axonframework/extensions/springcloud/commandhandling/SpringCloudCommandRouterTest.java
+++ b/springcloud/src/test/java/org/axonframework/extensions/springcloud/commandhandling/SpringCloudCommandRouterTest.java
@@ -554,14 +554,13 @@ public class SpringCloudCommandRouterTest {
     private SpringCloudCommandRouter createRouterFor(String host) {
         Registration localServiceInstance = mock(Registration.class);
         when(localServiceInstance.getUri()).thenReturn(URI.create("http://" + host));
-        SpringCloudCommandRouter router = SpringCloudCommandRouter.builder()
+        return SpringCloudCommandRouter.builder()
                                        .discoveryClient(discoveryClient)
                                        .localServiceInstance(localServiceInstance)
                                        .routingStrategy(routingStrategy)
                                        .serviceInstanceFilter(serviceInstance -> true)
                                        .consistentHashChangeListener(consistentHashChangeListener)
                                        .build();
-        return router;
     }
 
     private List<ServiceInstance> mockServiceInstances(int number) {

--- a/springcloud/src/test/java/org/axonframework/extensions/springcloud/commandhandling/SpringCloudCommandRouterTest.java
+++ b/springcloud/src/test/java/org/axonframework/extensions/springcloud/commandhandling/SpringCloudCommandRouterTest.java
@@ -183,9 +183,6 @@ public class SpringCloudCommandRouterTest {
                                                                                          .anyMatch(memberName -> memberName
                                                                                                  .contains(
                                                                                                          SERVICE_INSTANCE_ID))));
-       
-        //Returning to non-null mock for remaining tests
-        when(localServiceInstance.getMetadata()).thenReturn(serviceInstanceMetadata);
     }
 
     @Test


### PR DESCRIPTION
This is a code change to fix issue #9 where Spring Cloud Kubernetes is returning a null map when the SpringCloudCommandRouter requests the metadata for the local service instance.  I've added a simple null check after obtaining the map and, if it is not null, added the load factor, serialized command filter, and serialized command filter class name as before.

This PR resolves #9 