### PR TITLE
Graceful shutdown

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <axon.version>4.2</axon.version>
+        <axon.version>4.3-SNAPSHOT</axon.version>
         <spring-cloud.version>2.0.1.RELEASE</spring-cloud.version>
 
         <spring.version>5.1.4.RELEASE</spring.version>

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <axon.version>4.3-SNAPSHOT</axon.version>
+        <axon.version>4.3</axon.version>
         <spring-cloud.version>2.0.1.RELEASE</spring-cloud.version>
 
         <spring.version>5.1.4.RELEASE</spring.version>

--- a/springcloud/src/main/java/org/axonframework/extensions/springcloud/commandhandling/SpringHttpCommandBusConnector.java
+++ b/springcloud/src/main/java/org/axonframework/extensions/springcloud/commandhandling/SpringHttpCommandBusConnector.java
@@ -97,6 +97,9 @@ public class SpringHttpCommandBusConnector implements CommandBusConnector {
         this.executor = builder.executor;
     }
 
+    /**
+     * Start the Connector.
+     */
     @StartHandler(phase = Phase.EXTERNAL_CONNECTIONS)
     public void start() {
         shutdownLatch.initialize();

--- a/springcloud/src/main/java/org/axonframework/extensions/springcloud/commandhandling/SpringHttpCommandBusConnector.java
+++ b/springcloud/src/main/java/org/axonframework/extensions/springcloud/commandhandling/SpringHttpCommandBusConnector.java
@@ -44,10 +44,8 @@ import org.springframework.web.client.RestOperations;
 
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Executor;
 
 import static org.axonframework.commandhandling.GenericCommandResultMessage.asCommandResultMessage;

--- a/springcloud/src/test/java/org/axonframework/extensions/springcloud/commandhandling/SpringHttpCommandBusConnectorTest.java
+++ b/springcloud/src/test/java/org/axonframework/extensions/springcloud/commandhandling/SpringHttpCommandBusConnectorTest.java
@@ -21,6 +21,7 @@ import org.axonframework.commandhandling.callbacks.NoOpCallback;
 import org.axonframework.commandhandling.distributed.Member;
 import org.axonframework.commandhandling.distributed.SimpleMember;
 import org.axonframework.common.DirectExecutor;
+import org.axonframework.lifecycle.ShutdownInProgressException;
 import org.axonframework.messaging.MessageHandler;
 import org.axonframework.messaging.RemoteExceptionDescription;
 import org.axonframework.messaging.RemoteHandlingException;
@@ -98,6 +99,7 @@ public class SpringHttpCommandBusConnectorTest {
                                                    .serializer(serializer)
                                                    .executor(executor)
                                                    .build();
+        testSubject.start();
     }
 
     @Test
@@ -136,12 +138,12 @@ public class SpringHttpCommandBusConnectorTest {
         });
         testSubject.send(DESTINATION, COMMAND_MESSAGE, commandCallback);
 
-        testSubject.stopSendingCommands().get(400, TimeUnit.MILLISECONDS);
+        testSubject.initiateShutdown().get(400, TimeUnit.MILLISECONDS);
 
         try {
             testSubject.send(DESTINATION, COMMAND_MESSAGE, commandCallback);
             fail("Expected sending new commands to fail once connector is stopped.");
-        } catch (IllegalStateException e) {
+        } catch (ShutdownInProgressException e) {
             // expected
         }
 


### PR DESCRIPTION
Graceful shutdown of `SpringHttpCommandBusConnector`, following from [#891](https://github.com/AxonFramework/AxonFramework/issues/891).