### PR TITLE
[#13 & #1382] Allow Serializer Configuration & Support Spring Boot DevTools

### DIFF
--- a/springcloud-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/springcloud/autoconfig/SpringCloudAutoConfiguration.java
+++ b/springcloud-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/springcloud/autoconfig/SpringCloudAutoConfiguration.java
@@ -1,26 +1,11 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2020. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * Copyright (c) 2010-2018. Axon Framework
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -89,7 +74,8 @@ public class SpringCloudAutoConfiguration {
     public SpringCloudHttpBackupCommandRouter springCloudHttpBackupCommandRouter(DiscoveryClient discoveryClient,
                                                                                  Registration localServiceInstance,
                                                                                  RestTemplate restTemplate,
-                                                                                 RoutingStrategy routingStrategy) {
+                                                                                 RoutingStrategy routingStrategy,
+                                                                                 Serializer serializer) {
         return SpringCloudHttpBackupCommandRouter.builder()
                                                  .discoveryClient(discoveryClient)
                                                  .localServiceInstance(localServiceInstance)
@@ -102,6 +88,7 @@ public class SpringCloudAutoConfiguration {
                                                          properties.getSpringCloud()
                                                                    .getContextRootMetadataPropertyName()
                                                  )
+                                                 .serializer(serializer)
                                                  .build();
     }
 
@@ -110,11 +97,13 @@ public class SpringCloudAutoConfiguration {
     @ConditionalOnBean(DiscoveryClient.class)
     public CommandRouter springCloudCommandRouter(DiscoveryClient discoveryClient,
                                                   Registration localServiceInstance,
-                                                  RoutingStrategy routingStrategy) {
+                                                  RoutingStrategy routingStrategy,
+                                                  Serializer serializer) {
         return SpringCloudCommandRouter.builder()
                                        .discoveryClient(discoveryClient)
                                        .localServiceInstance(localServiceInstance)
                                        .routingStrategy(routingStrategy)
+                                       .serializer(serializer)
                                        .build();
     }
 

--- a/springcloud/pom.xml
+++ b/springcloud/pom.xml
@@ -90,6 +90,12 @@
     </dependencies>
 
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <artifactId>maven-jar-plugin</artifactId>

--- a/springcloud/src/main/java/org/axonframework/extensions/springcloud/commandhandling/SpringCloudHttpBackupCommandRouter.java
+++ b/springcloud/src/main/java/org/axonframework/extensions/springcloud/commandhandling/SpringCloudHttpBackupCommandRouter.java
@@ -22,6 +22,7 @@ import org.axonframework.commandhandling.distributed.Member;
 import org.axonframework.commandhandling.distributed.RoutingStrategy;
 import org.axonframework.commandhandling.distributed.commandfilter.DenyAll;
 import org.axonframework.common.AxonConfigurationException;
+import org.axonframework.serialization.Serializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.cloud.client.ServiceInstance;
@@ -244,6 +245,12 @@ public class SpringCloudHttpBackupCommandRouter extends SpringCloudCommandRouter
         @Override
         public Builder contextRootMetadataPropertyName(String contextRootMetadataPropertyName) {
             super.contextRootMetadataPropertyName(contextRootMetadataPropertyName);
+            return this;
+        }
+
+        @Override
+        public Builder serializer(Serializer serializer) {
+            super.serializer(serializer);
             return this;
         }
 

--- a/springcloud/src/main/resources/META-INF/spring-devtools.properties
+++ b/springcloud/src/main/resources/META-INF/spring-devtools.properties
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2010-2020. Axon Framework
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+restart.include.axon-springcloud=axon-springcloud-${project.version}.jar
+restart.include.axon-springcloud-spring-boot-autoconfigure=axon-springcloud-spring-boot-autoconfigure-${project.version}.jar


### PR DESCRIPTION
This pull request introduces a `spring-devtools.properties` file, including the modules required for restart. After local testing (at this stage uncertain how to provide test cases for this) it showed that [Spring Boot Devtools](https://docs.spring.io/spring-boot/docs/1.5.16.RELEASE/reference/html/using-boot-devtools.html) threw exceptions if any of the added jars was not included for restart.
With the adjustments in place, all worked as desired. An additional adjustment was made to the `pom.xml` to allow filtering of the project version into the `spring-devtools.properties` file.

Alongside this, this PR also introduces the possibility to configure the `Serializer` used by the `SpringCloudCommandRouter`. This was a request in issue #13 to mitigate the security concerns logged by `XStream`. This is however also a necessity for Spring Boot Devtools to work, as it contains a [known limitation](https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#using-boot-devtools-known-restart-limitations) on the matter.

This pull request is part of issue [#1382](https://github.com/AxonFramework/AxonFramework/issues/1382) and resolves #13 