### PR TITLE
Upgrade all dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,17 +50,20 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <axon.version>4.3.1</axon.version>
-        <spring-cloud.version>2.0.1.RELEASE</spring-cloud.version>
+        <axon.version>4.4.1</axon.version>
+        <spring-cloud-release.version>Hoxton.SR7</spring-cloud-release.version>
 
-        <spring.version>5.1.4.RELEASE</spring.version>
-        <spring.boot.version>2.1.2.RELEASE</spring.boot.version>
+        <spring.version>5.2.8.RELEASE</spring.version>
+        <spring.boot.version>2.3.2.RELEASE</spring.boot.version>
 
-        <slf4j.version>1.7.28</slf4j.version>
+        <slf4j.version>1.7.30</slf4j.version>
         <log4j.version>2.13.3</log4j.version>
 
-        <mockito.version>3.0.0</mockito.version>
-        <jackson.version>2.9.8</jackson.version>
+        <mockito.version>3.4.6</mockito.version>
+        <jackson.version>2.11.2</jackson.version>
+        <commons-io.version>2.7</commons-io.version>
+        <javax.jaxb-api.version>2.3.1</javax.jaxb-api.version>
+        <guava-collections.version>r03</guava-collections.version>
 
         <jacoco-maven-plugin.version>0.8.5</jacoco-maven-plugin.version>
     </properties>
@@ -138,20 +141,28 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>1.3.2</version>
+            <version>${commons-io.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <!-- Not pat of Java 9 by default. Adding it as a dependency makes it compatible with Java 8 -->
             <groupId>javax.xml.bind</groupId>
             <artifactId>jaxb-api</artifactId>
-            <version>2.3.0</version>
+            <version>${javax.jaxb-api.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-dependencies</artifactId>
+                <version>${spring-cloud-release.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
             <dependency>
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-context</artifactId>

--- a/springcloud-spring-boot-autoconfigure/pom.xml
+++ b/springcloud-spring-boot-autoconfigure/pom.xml
@@ -57,7 +57,6 @@
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-commons</artifactId>
-            <version>${spring-cloud.version}</version>
             <optional>true</optional>
         </dependency>
 
@@ -71,7 +70,6 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter</artifactId>
-            <version>${spring.boot.version}</version>
             <optional>true</optional>
             <exclusions>
                 <exclusion>

--- a/springcloud-spring-boot-starter/pom.xml
+++ b/springcloud-spring-boot-starter/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starters</artifactId>
-        <version>1.5.7.RELEASE</version>
+        <version>2.2.9.RELEASE</version>
         <relativePath />
     </parent>
 

--- a/springcloud/pom.xml
+++ b/springcloud/pom.xml
@@ -63,7 +63,6 @@
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-commons</artifactId>
-            <version>${spring-cloud.version}</version>
             <optional>true</optional>
         </dependency>
 
@@ -75,16 +74,16 @@
         </dependency>
 
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava-collections</artifactId>
-            <version>r03</version>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+            <version>${jackson.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>${jackson.version}</version>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava-collections</artifactId>
+            <version>${guava-collections.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
This pull request adjusts all dependency versions used by this extensions to more recent options.
Added, the `spring-cloud-dependencies` is added to the `dependencyManagement` section, thus the extension utilize the Spring Cloud release train. Due to this the extension will be more in line with Spring(Cloud)'s current versioning approach.

This PR resolves #21