### PR TITLE
Automatically expire ignored `ServiceInstances`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,10 +44,15 @@ jobs:
         run: |
           ./mvnw -B -U clean verify
 
+      - name: Build with Coverage reports
+        if: matrix.sonar-enabled
+        run: |
+          ./mvnw -B -U -Dcoverage clean verify
+
       - name: Sonar Analysis
         if: matrix.sonar-enabled
         run: |
-          ./mvnw -B -Pcoverage sonar:sonar \
+          ./mvnw -B sonar:sonar \
           -Dsonar.projectKey=AxonFramework_extension-springcloud \
           -Dsonar.organization=axonframework \
           -Dsonar.host.url=https://sonarcloud.io \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,6 +41,7 @@ jobs:
             ${{ runner.os }}-maven
 
       - name: Regular Build
+        if: ${{ !matrix.sonar-enabled }}
         run: |
           ./mvnw -B -U clean verify
 

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -38,13 +38,19 @@ jobs:
             ${{ runner.os }}-maven
 
       - name: Regular Build
+        if: ${{ !matrix.sonar-enabled }}
         run: |
           ./mvnw -B -U clean verify
+
+      - name: Build with Coverage reports
+        if: matrix.sonar-enabled
+        run: |
+          ./mvnw -B -U -Possrh -Dcoverage clean verify
 
       - name: Sonar Analysis
         if: ${{ success() && matrix.sonar-enabled && github.event.pull_request.head.repo.full_name == github.repository }}
         run: |
-          ./mvnw -B -Pcoverage sonar:sonar \
+          ./mvnw -B sonar:sonar \          
           -Dsonar.projectKey=AxonFramework_extension-springcloud \
           -Dsonar.organization=axonframework \
           -Dsonar.host.url=https://sonarcloud.io \

--- a/springcloud/src/main/java/org/axonframework/extensions/springcloud/commandhandling/mode/IgnoreListingDiscoveryMode.java
+++ b/springcloud/src/main/java/org/axonframework/extensions/springcloud/commandhandling/mode/IgnoreListingDiscoveryMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020. Axon Framework
+ * Copyright (c) 2010-2022. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,22 +23,31 @@ import org.slf4j.LoggerFactory;
 import org.springframework.cloud.client.ServiceInstance;
 
 import java.lang.invoke.MethodHandles;
+import java.time.Clock;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
 import static org.axonframework.common.BuilderUtils.assertNonNull;
+import static org.axonframework.common.BuilderUtils.assertStrictPositive;
 
 /**
  * Wrapper implementation of the {@link CapabilityDiscoveryMode}, delegating all operations to another {@code
  * CapabilityDiscoveryMode} instance. When discovering {@link #capabilities(ServiceInstance)}, the given {@link
  * ServiceInstance} might be added to the ignored instance list.
  * <p>
- * {@code ServiceInstance}s are ignored whenever a {@link ServiceInstanceClientException} is thrown, upon which the
+ * {@code ServiceInstances} are ignored whenever a {@link ServiceInstanceClientException} is thrown, upon which the
  * {@code ServiceInstance} is stored for subsequent invocation. On the next {@link #capabilities(ServiceInstance)}
  * iteration, the given {@code ServiceInstance} is validated to <b>not</b> be present in the set of ignored service
  * instance identifiers.
+ * <p>
+ * Ignored {@code ServiceInstances} are evicted from the list after a configurable {@code expireThreshold} (through the
+ * {@link Builder#expireThreshold(long)}. Eviction occurs during <em>any</em>> {@link #capabilities(ServiceInstance)}
+ * invocation. It will thus run in line with the heartbeat configuration of the chosen Spring Cloud Discovery
+ * implementation.
  *
  * @author Steven van Beelen
  * @since 4.4
@@ -47,14 +56,22 @@ public class IgnoreListingDiscoveryMode extends AbstractCapabilityDiscoveryMode<
 
     private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-    private final CapabilityDiscoveryMode delegate;
+    /**
+     * {@link Clock} instance used to set the expiry time of ignored {@link ServiceInstance ServiceInstances}. May be
+     * adjusted to use a different timezone, or for testing purposes.
+     */
+    public static Clock clock = Clock.systemUTC();
 
-    private final Set<ServiceInstance> ignoredServices = new HashSet<>();
+    private final CapabilityDiscoveryMode delegate;
+    private final long expireThreshold;
+
+    private final Map<ServiceInstance, Long> ignoredServices = new HashMap<>();
 
     /**
      * Instantiate a {@link Builder} to be able to create a {@link IgnoreListingDiscoveryMode}.
      * <p>
-     * The delegate {@link CapabilityDiscoveryMode} is a <b>hard requirement</b> and as such should be provided.
+     * The {@code expireThreshold} is defaulted to {@code 60000} milliseconds. The delegate {@link
+     * CapabilityDiscoveryMode} is a <b>hard requirement</b> and as such should be provided.
      *
      * @return a {@link Builder} to be able to create a {@link IgnoreListingDiscoveryMode}
      */
@@ -73,6 +90,7 @@ public class IgnoreListingDiscoveryMode extends AbstractCapabilityDiscoveryMode<
     protected IgnoreListingDiscoveryMode(Builder builder) {
         super(builder);
         this.delegate = builder.delegate;
+        this.expireThreshold = builder.expireThreshold;
     }
 
     @Override
@@ -92,7 +110,8 @@ public class IgnoreListingDiscoveryMode extends AbstractCapabilityDiscoveryMode<
         try {
             return delegate.capabilities(serviceInstance);
         } catch (ServiceInstanceClientException e) {
-            ignoredServices.add(serviceInstance);
+            long expiryTime = clock.instant().toEpochMilli() + expireThreshold;
+            ignoredServices.put(serviceInstance, expiryTime);
             logger.info("Added ServiceInstance [{}] under host [{}] and port [{}] to the denied list, "
                                 + "since we could not retrieve the required member capabilities from it.",
                         serviceInstance.getServiceId(), serviceInstance.getHost(), serviceInstance.getPort(), e);
@@ -101,7 +120,21 @@ public class IgnoreListingDiscoveryMode extends AbstractCapabilityDiscoveryMode<
     }
 
     private boolean shouldIgnore(ServiceInstance service) {
-        return ignoredServices.stream().anyMatch(ignoredService -> equals(ignoredService, service));
+        long currentTime = clock.instant().toEpochMilli();
+        boolean shouldIgnore = false;
+        Set<ServiceInstance> expiredInstances = new HashSet<>();
+
+        for (Map.Entry<ServiceInstance, Long> instance : ignoredServices.entrySet()) {
+            if (equals(instance.getKey(), service)) {
+                shouldIgnore = true;
+            }
+            if (instance.getValue() <= currentTime) {
+                expiredInstances.add(instance.getKey());
+            }
+        }
+        expiredInstances.forEach(ignoredServices::remove);
+
+        return shouldIgnore;
     }
 
     /**
@@ -131,11 +164,13 @@ public class IgnoreListingDiscoveryMode extends AbstractCapabilityDiscoveryMode<
     /**
      * Builder class to instantiate a {@link IgnoreListingDiscoveryMode}.
      * <p>
-     * The delegate {@link CapabilityDiscoveryMode} is a <b>hard requirement</b> and as such should be provided.
+     * The {@code expireThreshold} is defaulted to {@code 60000} milliseconds. The delegate {@link
+     * CapabilityDiscoveryMode} is a <b>hard requirement</b> and as such should be provided.
      */
     public static class Builder extends AbstractCapabilityDiscoveryMode.Builder<IgnoreListingDiscoveryMode> {
 
         private CapabilityDiscoveryMode delegate;
+        private long expireThreshold = 60000;
 
         /**
          * Sets the delegate {@link CapabilityDiscoveryMode} used to delegate the {@link #capabilities(ServiceInstance)}
@@ -148,6 +183,21 @@ public class IgnoreListingDiscoveryMode extends AbstractCapabilityDiscoveryMode<
         public Builder delegate(CapabilityDiscoveryMode delegate) {
             assertNonNull(delegate, "The delegate CapabilityDiscovery may not be null or empty");
             this.delegate = delegate;
+            return this;
+        }
+
+        /**
+         * Defines the expiry threshold of ignored {@link ServiceInstance ServiceInstances} in milliseconds. Once the
+         * threshold is met they will automatically be considered again for their {@link MemberCapabilities}. Defaults
+         * to {@code 60000} milliseconds.
+         *
+         * @param expireThreshold The expiry threshold in milliseconds for an ignored {@link ServiceInstance} to be
+         *                        reconsidered.
+         * @return The current Builder instance, for fluent interfacing.
+         */
+        public Builder expireThreshold(long expireThreshold) {
+            assertStrictPositive(expireThreshold, "The expire threshold should be strictly positive");
+            this.expireThreshold = expireThreshold;
             return this;
         }
 

--- a/springcloud/src/test/java/org/axonframework/extensions/springcloud/commandhandling/mode/IgnoreListingDiscoveryModeTest.java
+++ b/springcloud/src/test/java/org/axonframework/extensions/springcloud/commandhandling/mode/IgnoreListingDiscoveryModeTest.java
@@ -24,6 +24,7 @@ import org.springframework.cloud.client.ServiceInstance;
 
 import java.net.URI;
 import java.time.Clock;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.Map;
@@ -98,7 +99,7 @@ class IgnoreListingDiscoveryModeTest {
         IgnoreListingDiscoveryMode testSubjectWithCustomExpireThreshold =
                 IgnoreListingDiscoveryMode.builder()
                                           .delegate(delegate)
-                                          .expireThreshold(testExpireThresholdMs)
+                                          .expireThreshold(Duration.ofMillis(testExpireThresholdMs))
                                           .build();
 
         ServiceInstance testInstanceOne = new StubServiceInstance("idOne", "hostOne", 1);
@@ -160,8 +161,8 @@ class IgnoreListingDiscoveryModeTest {
     void testBuildWithNegativeOrZeroExpireThresholdThrowsAxonConfigurationException() {
         IgnoreListingDiscoveryMode.Builder builderTestSubject = IgnoreListingDiscoveryMode.builder();
 
-        assertThrows(AxonConfigurationException.class, () -> builderTestSubject.expireThreshold(-1));
-        assertThrows(AxonConfigurationException.class, () -> builderTestSubject.expireThreshold(0));
+        assertThrows(AxonConfigurationException.class, () -> builderTestSubject.expireThreshold(Duration.ofMinutes(-1)));
+        assertThrows(AxonConfigurationException.class, () -> builderTestSubject.expireThreshold(Duration.ZERO));
     }
 
     private static class StubServiceInstance implements ServiceInstance {

--- a/springcloud/src/test/java/org/axonframework/extensions/springcloud/commandhandling/mode/IgnoreListingDiscoveryModeTest.java
+++ b/springcloud/src/test/java/org/axonframework/extensions/springcloud/commandhandling/mode/IgnoreListingDiscoveryModeTest.java
@@ -1,10 +1,32 @@
+/*
+ * Copyright (c) 2010-2022. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.axonframework.extensions.springcloud.commandhandling.mode;
 
 import org.axonframework.commandhandling.distributed.CommandMessageFilter;
 import org.axonframework.commandhandling.distributed.commandfilter.AcceptAll;
+import org.axonframework.common.AxonConfigurationException;
 import org.junit.jupiter.api.*;
 import org.springframework.cloud.client.ServiceInstance;
 
+import java.net.URI;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -68,5 +90,120 @@ class IgnoreListingDiscoveryModeTest {
         Optional<MemberCapabilities> result = testSubject.capabilities(testServiceInstance);
 
         assertFalse(result.isPresent());
+    }
+
+    @Test
+    void testCapabilitiesEvictsServiceInstancesAfterTheExpireThresholdIsReached() {
+        int testExpireThresholdMs = 5000;
+        IgnoreListingDiscoveryMode testSubjectWithCustomExpireThreshold =
+                IgnoreListingDiscoveryMode.builder()
+                                          .delegate(delegate)
+                                          .expireThreshold(testExpireThresholdMs)
+                                          .build();
+
+        ServiceInstance testInstanceOne = new StubServiceInstance("idOne", "hostOne", 1);
+        ServiceInstance testInstanceTwo = new StubServiceInstance("idTwo", "hostTwo", 2);
+        ServiceInstance testInstanceThree = new StubServiceInstance("idThree", "hostThree", 3);
+        ServiceInstance testInstanceFour = new StubServiceInstance("idFour", "hostFour", 4);
+        MemberCapabilities expectedCapabilities = new DefaultMemberCapabilities(LOAD_FACTOR, COMMAND_MESSAGE_FILTER);
+
+        when(delegate.capabilities(testInstanceOne)).thenThrow(ServiceInstanceClientException.class)
+                                                    .thenReturn(Optional.of(expectedCapabilities));
+        when(delegate.capabilities(testInstanceTwo)).thenThrow(ServiceInstanceClientException.class)
+                                                    .thenReturn(Optional.of(expectedCapabilities));
+        when(delegate.capabilities(testInstanceThree)).thenThrow(ServiceInstanceClientException.class)
+                                                      .thenReturn(Optional.of(expectedCapabilities));
+        when(delegate.capabilities(testInstanceFour)).thenReturn(Optional.of(expectedCapabilities));
+
+        Instant now = Instant.now();
+        IgnoreListingDiscoveryMode.clock = Clock.fixed(now, ZoneId.of("UTC"));
+        assertFalse(testSubjectWithCustomExpireThreshold.capabilities(testInstanceOne).isPresent());
+        // the second invocation would still net an empty optional, as the ServiceInstance is ignored
+        assertFalse(testSubjectWithCustomExpireThreshold.capabilities(testInstanceOne).isPresent());
+
+        IgnoreListingDiscoveryMode.clock = Clock.fixed(now.plusMillis(testExpireThresholdMs / 2), ZoneId.of("UTC"));
+        assertFalse(testSubjectWithCustomExpireThreshold.capabilities(testInstanceTwo).isPresent());
+        // we adjusted the clock, but both instance one and two are still ignored as the threshold isn't met
+        assertFalse(testSubjectWithCustomExpireThreshold.capabilities(testInstanceOne).isPresent());
+        assertFalse(testSubjectWithCustomExpireThreshold.capabilities(testInstanceTwo).isPresent());
+
+
+        IgnoreListingDiscoveryMode.clock = Clock.fixed(now.plusMillis(testExpireThresholdMs - 1), ZoneId.of("UTC"));
+        assertFalse(testSubjectWithCustomExpireThreshold.capabilities(testInstanceThree).isPresent());
+        // we adjusted the clock more, but instance's one, two, and three are still ignored as the threshold isn't met
+        assertFalse(testSubjectWithCustomExpireThreshold.capabilities(testInstanceOne).isPresent());
+        assertFalse(testSubjectWithCustomExpireThreshold.capabilities(testInstanceTwo).isPresent());
+        assertFalse(testSubjectWithCustomExpireThreshold.capabilities(testInstanceThree).isPresent());
+
+
+        IgnoreListingDiscoveryMode.clock = Clock.fixed(now.plusMillis(testExpireThresholdMs * 2), ZoneId.of("UTC"));
+        // instance four was not ignored to begin with through mocking...
+        Optional<MemberCapabilities> resultFour = testSubjectWithCustomExpireThreshold.capabilities(testInstanceFour);
+        assertTrue(resultFour.isPresent());
+        assertEquals(expectedCapabilities, resultFour.get());
+
+        // ...but it has also reintroduced instance's one, two, and three for evaluation
+        Optional<MemberCapabilities> resultOne = testSubjectWithCustomExpireThreshold.capabilities(testInstanceOne);
+        assertTrue(resultOne.isPresent());
+        assertEquals(expectedCapabilities, resultOne.get());
+
+        Optional<MemberCapabilities> resultTwo = testSubjectWithCustomExpireThreshold.capabilities(testInstanceTwo);
+        assertTrue(resultTwo.isPresent());
+        assertEquals(expectedCapabilities, resultTwo.get());
+
+        Optional<MemberCapabilities> resultThree = testSubjectWithCustomExpireThreshold.capabilities(testInstanceThree);
+        assertTrue(resultThree.isPresent());
+        assertEquals(expectedCapabilities, resultThree.get());
+    }
+
+    @Test
+    void testBuildWithNegativeOrZeroExpireThresholdThrowsAxonConfigurationException() {
+        IgnoreListingDiscoveryMode.Builder builderTestSubject = IgnoreListingDiscoveryMode.builder();
+
+        assertThrows(AxonConfigurationException.class, () -> builderTestSubject.expireThreshold(-1));
+        assertThrows(AxonConfigurationException.class, () -> builderTestSubject.expireThreshold(0));
+    }
+
+    private static class StubServiceInstance implements ServiceInstance {
+
+        private final String serviceId;
+        private final String host;
+        private final int port;
+
+        private StubServiceInstance(String serviceId, String host, int port) {
+            this.serviceId = serviceId;
+            this.host = host;
+            this.port = port;
+        }
+
+        @Override
+        public String getServiceId() {
+            return serviceId;
+        }
+
+        @Override
+        public String getHost() {
+            return host;
+        }
+
+        @Override
+        public int getPort() {
+            return port;
+        }
+
+        @Override
+        public boolean isSecure() {
+            return false;
+        }
+
+        @Override
+        public URI getUri() {
+            return null;
+        }
+
+        @Override
+        public Map<String, String> getMetadata() {
+            return null;
+        }
     }
 }


### PR DESCRIPTION
This pull request updates the `IgnoreListingDiscoveryMode` to evict ignored `ServiceInstances` after a configurable threshold.
To that end, whenever a `ServiceInstance` is ignored the time of ignoring plus the `expireThreshold` is stored with it.

To set the time of ignoring an instance, a `public static Clock` is added to the `IgnoreListingDiscoveryMode`.
Opening up the `Clock` provides users the freedom to change it, but also enables easier testing.

The `IgnoreListingDiscoveryMode` validates ignored `ServiceInstance` for eviction on _any_ `capabilities(ServiceInstance)` invocation.
Doing so ensure the `IgnoreListingDiscoveryMode` moves in line with the heartbeats of the chosen Spring Cloud Discovery implementation.

This pull request resolves #6.