### PR TITLE
Add Spring Boot 3 autoconfigure support.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,8 @@ jobs:
           - java-version: 8
             sonar-enabled: false
           - java-version: 11
+            sonar-enabled: false
+          - java-version: 17
             sonar-enabled: true
 
     steps:

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -13,8 +13,10 @@ jobs:
           - java-version: 8
             sonar-enabled: false
           - java-version: 11
+            sonar-enabled: false
+          - java-version: 17
             sonar-enabled: true
-      fail-fast: false # run both to the end
+      fail-fast: false # run all to the end
 
     steps:
       - name: Checkout code

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
     <groupId>org.axonframework.extensions.springcloud</groupId>
     <artifactId>axon-springcloud-parent</artifactId>
-    <version>4.6.1-SNAPSHOT</version>
+    <version>4.7.0-SNAPSHOT</version>
     <modules>
         <module>springcloud</module>
         <module>springcloud-spring-boot-autoconfigure</module>
@@ -399,7 +399,15 @@
                 </plugins>
             </build>
         </profile>
-
+        <profile>
+            <id>java17-modules</id>
+            <activation>
+                <jdk>[17,)</jdk>
+            </activation>
+            <modules>
+                <module>springcloud-spring-boot-3-integrationtests</module>
+            </modules>
+        </profile>
     </profiles>
 
     <repositories>

--- a/springcloud-spring-boot-3-integrationtests/pom.xml
+++ b/springcloud-spring-boot-3-integrationtests/pom.xml
@@ -1,0 +1,197 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2010-2023. Axon Framework
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.0.2</version>
+        <relativePath/>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>axon-springcloud-spring-boot-3-integrationtests</artifactId>
+    <groupId>org.axonframework.extensions.springcloud</groupId>
+
+    <name>Axon Framework Spring Cloud Extension Spring Boot 3 Integration Tests</name>
+    <description>
+        Module used to test the integration with Spring Boot 3
+    </description>
+    <version>4.7.0-SNAPSHOT</version>
+
+    <packaging>jar</packaging>
+
+    <properties>
+        <spring-cloud.version>2022.0.1</spring-cloud.version>
+        <testcoontainers.version>1.17.6</testcoontainers.version>
+
+        <jar-plugin.version>3.3.0</jar-plugin.version>
+        <jacoco-plugin.version>0.8.8</jacoco-plugin.version>
+    </properties>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.axonframework</groupId>
+            <artifactId>axon-spring-boot-autoconfigure</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.axonframework.extensions.springcloud</groupId>
+            <artifactId>axon-springcloud-spring-boot-starter</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-log4j2</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-actuator</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>testcontainers-bom</artifactId>
+                <version>${testcoontainers.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-dependencies</artifactId>
+                <version>${spring-cloud.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>${jar-plugin.version}</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>17</source>
+                    <target>17</target>
+                    <encoding>UTF-8</encoding>
+                    <showWarnings>true</showWarnings>
+                    <showDeprecation>true</showDeprecation>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>coverage</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <version>${jacoco-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>prepare-agent</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>report</id>
+                                <phase>prepare-package</phase>
+                                <goals>
+                                    <goal>report</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+    <repositories>
+        <repository>
+            <id>sonatype-snapshots</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </repository>
+    </repositories>
+
+</project>

--- a/springcloud-spring-boot-3-integrationtests/src/test/java/org/axonframework/extensions/mongo/integration/DistributedCommandBusIntegrationTest.java
+++ b/springcloud-spring-boot-3-integrationtests/src/test/java/org/axonframework/extensions/mongo/integration/DistributedCommandBusIntegrationTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2010-2023. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.extensions.mongo.integration;
+
+import org.axonframework.commandhandling.CommandMessage;
+import org.axonframework.commandhandling.GenericCommandMessage;
+import org.axonframework.commandhandling.NoHandlerForCommandException;
+import org.axonframework.commandhandling.distributed.DistributedCommandBus;
+import org.axonframework.messaging.GenericMessage;
+import org.axonframework.messaging.Message;
+import org.junit.jupiter.api.*;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.cloud.client.discovery.DiscoveryClient;
+import org.springframework.context.annotation.EnableMBeanExport;
+import org.springframework.jmx.support.RegistrationPolicy;
+import org.springframework.test.context.ContextConfiguration;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.*;
+
+@Testcontainers
+class DistributedCommandBusIntegrationTest {
+
+    public static final DockerImageName EUREKA_SERVER_IMAGE =
+            DockerImageName.parse("springcloud/eureka:latest");
+
+    private ApplicationContextRunner testApplicationContext;
+
+    @Container
+    private static final GenericContainer EUREKA_SERVER_CONTAINER =
+            new GenericContainer(EUREKA_SERVER_IMAGE).withExposedPorts(8761);
+
+    @BeforeEach
+    void setUp() {
+        testApplicationContext = new ApplicationContextRunner()
+                .withPropertyValues("axon.axonserver.enabled=false")
+                .withPropertyValues("axon.distributed.enabled=true")
+                .withPropertyValues("eureka.client.serviceUrl.defaultZone=http://localhost:"
+                                            + EUREKA_SERVER_CONTAINER.getMappedPort(8761) + "/eureka")
+                .withPropertyValues("eureka.instance.preferIpAddress=true")
+                .withPropertyValues("spring.application.name=test-app")
+                .withUserConfiguration(DefaultContext.class);
+    }
+
+    @Test
+    void willUseADistributedCommandBus() {
+        testApplicationContext
+                .run(context -> {
+                    DiscoveryClient discoveryClient = context.getBean(DiscoveryClient.class);
+                    assertNotNull(discoveryClient);
+                    DistributedCommandBus commandBus = context.getBean(DistributedCommandBus.class);
+                    assertNotNull(commandBus);
+                    subscribeCommandHandler(commandBus);
+                    executeCommand(commandBus);
+                });
+    }
+
+    @Test
+    void failsWhenNotRegistered() {
+        testApplicationContext
+                .run(context -> {
+                    DiscoveryClient discoveryClient = context.getBean(DiscoveryClient.class);
+                    assertNotNull(discoveryClient);
+                    DistributedCommandBus commandBus = context.getBean(DistributedCommandBus.class);
+                    assertNotNull(commandBus);
+                    executeCommandWhileNotRegistered(commandBus);
+                });
+    }
+
+    private void subscribeCommandHandler(DistributedCommandBus commandBus) {
+        commandBus.subscribe("testCommand", e -> "correct");
+    }
+
+    private void executeCommand(DistributedCommandBus commandBus) {
+        Message message = new GenericMessage("hi");
+        CommandMessage command = new GenericCommandMessage(message, "testCommand");
+        AtomicReference<String> result = new AtomicReference<>();
+        commandBus.dispatch(command, (commandMessage, commandResultMessage) -> {
+            result.set((String) commandResultMessage.getPayload());
+        });
+        await().atMost(Duration.ofSeconds(5)).until(() -> result.get() != null);
+        assertEquals("correct", result.get());
+    }
+
+    private void executeCommandWhileNotRegistered(DistributedCommandBus commandBus) {
+        Message message = new GenericMessage("hi");
+        CommandMessage command = new GenericCommandMessage(message, "anotherCommand");
+        AtomicReference<Throwable> result = new AtomicReference<>();
+        commandBus.dispatch(command, (commandMessage, commandResultMessage) -> {
+            result.set(commandResultMessage.exceptionResult());
+        });
+        await().atMost(Duration.ofSeconds(5)).until(() -> result.get() != null);
+        assertTrue(result.get() instanceof NoHandlerForCommandException);
+    }
+
+    @ContextConfiguration
+    @EnableAutoConfiguration
+    @EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)
+    public static class DefaultContext {
+
+    }
+}

--- a/springcloud-spring-boot-3-integrationtests/src/test/resources/logback-test.xml
+++ b/springcloud-spring-boot-3-integrationtests/src/test/resources/logback-test.xml
@@ -1,0 +1,31 @@
+<!--
+  ~ Copyright (c) 2010-2023. Axon Framework
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+    <logger name="org.testcontainers" level="INFO"/>
+    <logger name="com.github.dockerjava" level="WARN"/>
+    <logger name="com.github.dockerjava.zerodep.shaded.org.apache.hc.client5.http.wire" level="OFF"/>
+</configuration>

--- a/springcloud-spring-boot-autoconfigure/pom.xml
+++ b/springcloud-spring-boot-autoconfigure/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.axonframework.extensions.springcloud</groupId>
         <artifactId>axon-springcloud-parent</artifactId>
-        <version>4.6.1-SNAPSHOT</version>
+        <version>4.7.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>axon-springcloud-spring-boot-autoconfigure</artifactId>

--- a/springcloud-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/springcloud/autoconfig/RoutingStrategyAutoConfiguration.java
+++ b/springcloud-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/springcloud/autoconfig/RoutingStrategyAutoConfiguration.java
@@ -21,11 +21,11 @@ package org.axonframework.extensions.springcloud.autoconfig;
 import org.axonframework.commandhandling.distributed.AnnotationRoutingStrategy;
 import org.axonframework.commandhandling.distributed.RoutingStrategy;
 import org.axonframework.commandhandling.distributed.UnresolvedRoutingKeyPolicy;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
 /**
  * Auto configuration for {@link RoutingStrategy}.
@@ -33,7 +33,7 @@ import org.springframework.context.annotation.Configuration;
  * @author Milan Savic
  * @since 3.1.1
  */
-@Configuration
+@AutoConfiguration
 @AutoConfigureBefore(SpringCloudAutoConfiguration.class)
 @ConditionalOnExpression("${axon.distributed.enabled:false}")
 public class RoutingStrategyAutoConfiguration {

--- a/springcloud-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/springcloud/autoconfig/SpringCloudAutoConfiguration.java
+++ b/springcloud-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/springcloud/autoconfig/SpringCloudAutoConfiguration.java
@@ -32,6 +32,7 @@ import org.axonframework.extensions.springcloud.commandhandling.mode.RestCapabil
 import org.axonframework.serialization.Serializer;
 import org.axonframework.springboot.autoconfig.InfraConfiguration;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
@@ -44,7 +45,6 @@ import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.cloud.client.discovery.simple.SimpleDiscoveryClientAutoConfiguration;
 import org.springframework.cloud.client.serviceregistry.Registration;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.springframework.web.client.RestTemplate;
 
@@ -55,7 +55,7 @@ import org.springframework.web.client.RestTemplate;
  * @author Steven van Beelen
  * @since 3.0
  */
-@Configuration
+@AutoConfiguration
 @AutoConfigureAfter({
         RoutingStrategyAutoConfiguration.class,
         SimpleDiscoveryClientAutoConfiguration.class

--- a/springcloud-spring-boot-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/springcloud-spring-boot-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,2 @@
+org.axonframework.extensions.springcloud.autoconfig.RoutingStrategyAutoConfiguration
+org.axonframework.extensions.springcloud.autoconfig.SpringCloudAutoConfiguration

--- a/springcloud-spring-boot-starter/pom.xml
+++ b/springcloud-spring-boot-starter/pom.xml
@@ -26,7 +26,7 @@
 
     <groupId>org.axonframework.extensions.springcloud</groupId>
     <artifactId>axon-springcloud-spring-boot-starter</artifactId>
-    <version>4.6.1-SNAPSHOT</version>
+    <version>4.7.0-SNAPSHOT</version>
 
     <name>Axon Framework Spring Cloud Extension - Spring Boot Starter</name>
     <description>Spring Boot Starter module for the Spring Cloud Extension of Axon Framework</description>

--- a/springcloud/pom.xml
+++ b/springcloud/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.axonframework.extensions.springcloud</groupId>
         <artifactId>axon-springcloud-parent</artifactId>
-        <version>4.6.1-SNAPSHOT</version>
+        <version>4.7.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>axon-springcloud</artifactId>

--- a/springcloud/src/main/java/org/axonframework/extensions/springcloud/commandhandling/MessageRoutingInformation.java
+++ b/springcloud/src/main/java/org/axonframework/extensions/springcloud/commandhandling/MessageRoutingInformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/springcloud/src/main/java/org/axonframework/extensions/springcloud/commandhandling/SpringCloudCommandRouter.java
+++ b/springcloud/src/main/java/org/axonframework/extensions/springcloud/commandhandling/SpringCloudCommandRouter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/springcloud/src/main/java/org/axonframework/extensions/springcloud/commandhandling/SpringCloudHttpBackupCommandRouter.java
+++ b/springcloud/src/main/java/org/axonframework/extensions/springcloud/commandhandling/SpringCloudHttpBackupCommandRouter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/springcloud/src/main/java/org/axonframework/extensions/springcloud/commandhandling/SpringHttpCommandBusConnector.java
+++ b/springcloud/src/main/java/org/axonframework/extensions/springcloud/commandhandling/SpringHttpCommandBusConnector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/springcloud/src/main/java/org/axonframework/extensions/springcloud/commandhandling/SpringHttpDispatchMessage.java
+++ b/springcloud/src/main/java/org/axonframework/extensions/springcloud/commandhandling/SpringHttpDispatchMessage.java
@@ -1,10 +1,11 @@
 /*
- * Copyright (c) 2010-2017. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/springcloud/src/main/java/org/axonframework/extensions/springcloud/commandhandling/SpringHttpReplyMessage.java
+++ b/springcloud/src/main/java/org/axonframework/extensions/springcloud/commandhandling/SpringHttpReplyMessage.java
@@ -1,10 +1,11 @@
 /*
- * Copyright (c) 2010-2017. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/springcloud/src/main/java/org/axonframework/extensions/springcloud/commandhandling/mode/AbstractCapabilityDiscoveryMode.java
+++ b/springcloud/src/main/java/org/axonframework/extensions/springcloud/commandhandling/mode/AbstractCapabilityDiscoveryMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/springcloud/src/main/java/org/axonframework/extensions/springcloud/commandhandling/mode/AcceptAllCommandsDiscoveryMode.java
+++ b/springcloud/src/main/java/org/axonframework/extensions/springcloud/commandhandling/mode/AcceptAllCommandsDiscoveryMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/springcloud/src/main/java/org/axonframework/extensions/springcloud/commandhandling/mode/CapabilityDiscoveryMode.java
+++ b/springcloud/src/main/java/org/axonframework/extensions/springcloud/commandhandling/mode/CapabilityDiscoveryMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/springcloud/src/main/java/org/axonframework/extensions/springcloud/commandhandling/mode/DefaultMemberCapabilities.java
+++ b/springcloud/src/main/java/org/axonframework/extensions/springcloud/commandhandling/mode/DefaultMemberCapabilities.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/springcloud/src/main/java/org/axonframework/extensions/springcloud/commandhandling/mode/IgnoreListingDiscoveryMode.java
+++ b/springcloud/src/main/java/org/axonframework/extensions/springcloud/commandhandling/mode/IgnoreListingDiscoveryMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/springcloud/src/main/java/org/axonframework/extensions/springcloud/commandhandling/mode/MemberCapabilities.java
+++ b/springcloud/src/main/java/org/axonframework/extensions/springcloud/commandhandling/mode/MemberCapabilities.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/springcloud/src/main/java/org/axonframework/extensions/springcloud/commandhandling/mode/MemberCapabilitiesController.java
+++ b/springcloud/src/main/java/org/axonframework/extensions/springcloud/commandhandling/mode/MemberCapabilitiesController.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2010-2023. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.axonframework.extensions.springcloud.commandhandling.mode;
 
 import org.axonframework.common.AxonConfigurationException;

--- a/springcloud/src/main/java/org/axonframework/extensions/springcloud/commandhandling/mode/RestCapabilityDiscoveryMode.java
+++ b/springcloud/src/main/java/org/axonframework/extensions/springcloud/commandhandling/mode/RestCapabilityDiscoveryMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/springcloud/src/main/java/org/axonframework/extensions/springcloud/commandhandling/mode/SerializedMemberCapabilities.java
+++ b/springcloud/src/main/java/org/axonframework/extensions/springcloud/commandhandling/mode/SerializedMemberCapabilities.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/springcloud/src/main/java/org/axonframework/extensions/springcloud/commandhandling/mode/ServiceInstanceClientException.java
+++ b/springcloud/src/main/java/org/axonframework/extensions/springcloud/commandhandling/mode/ServiceInstanceClientException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/springcloud/src/main/resources/META-INF/spring-devtools.properties
+++ b/springcloud/src/main/resources/META-INF/spring-devtools.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2010-2020. Axon Framework
+# Copyright (c) 2010-2023. Axon Framework
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/springcloud/src/test/java/org/axonframework/extensions/springcloud/commandhandling/SpringCloudCommandRouterTest.java
+++ b/springcloud/src/test/java/org/axonframework/extensions/springcloud/commandhandling/SpringCloudCommandRouterTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/springcloud/src/test/java/org/axonframework/extensions/springcloud/commandhandling/SpringHttpCommandBusConnectorTest.java
+++ b/springcloud/src/test/java/org/axonframework/extensions/springcloud/commandhandling/SpringHttpCommandBusConnectorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/springcloud/src/test/java/org/axonframework/extensions/springcloud/commandhandling/mode/AcceptAllCommandsDiscoveryModeTest.java
+++ b/springcloud/src/test/java/org/axonframework/extensions/springcloud/commandhandling/mode/AcceptAllCommandsDiscoveryModeTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2010-2023. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.axonframework.extensions.springcloud.commandhandling.mode;
 
 import org.axonframework.commandhandling.distributed.commandfilter.AcceptAll;

--- a/springcloud/src/test/java/org/axonframework/extensions/springcloud/commandhandling/mode/DefaultMemberCapabilitiesTest.java
+++ b/springcloud/src/test/java/org/axonframework/extensions/springcloud/commandhandling/mode/DefaultMemberCapabilitiesTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2010-2023. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.axonframework.extensions.springcloud.commandhandling.mode;
 
 import org.axonframework.commandhandling.distributed.CommandMessageFilter;

--- a/springcloud/src/test/java/org/axonframework/extensions/springcloud/commandhandling/mode/IgnoreListingDiscoveryModeTest.java
+++ b/springcloud/src/test/java/org/axonframework/extensions/springcloud/commandhandling/mode/IgnoreListingDiscoveryModeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/springcloud/src/test/java/org/axonframework/extensions/springcloud/commandhandling/mode/MemberCapabilitiesControllerTest.java
+++ b/springcloud/src/test/java/org/axonframework/extensions/springcloud/commandhandling/mode/MemberCapabilitiesControllerTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2010-2023. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.axonframework.extensions.springcloud.commandhandling.mode;
 
 import org.axonframework.common.AxonConfigurationException;

--- a/springcloud/src/test/java/org/axonframework/extensions/springcloud/commandhandling/mode/RestCapabilityDiscoveryModeTest.java
+++ b/springcloud/src/test/java/org/axonframework/extensions/springcloud/commandhandling/mode/RestCapabilityDiscoveryModeTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2010-2023. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.axonframework.extensions.springcloud.commandhandling.mode;
 
 import org.axonframework.commandhandling.distributed.CommandMessageFilter;

--- a/springcloud/src/test/java/org/axonframework/extensions/springcloud/commandhandling/mode/SerializedMemberCapabilitiesTest.java
+++ b/springcloud/src/test/java/org/axonframework/extensions/springcloud/commandhandling/mode/SerializedMemberCapabilitiesTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2010-2023. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.axonframework.extensions.springcloud.commandhandling.mode;
 
 import org.axonframework.commandhandling.distributed.CommandMessageFilter;

--- a/springcloud/src/test/java/org/axonframework/extensions/springcloud/commandhandling/utils/TestSerializer.java
+++ b/springcloud/src/test/java/org/axonframework/extensions/springcloud/commandhandling/utils/TestSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
At the same time, add an integration test for Spring Boot 3, add Java 17 job, and use it for Sonar, and move from 4.6.1-SNAPSHOT to 4.7.0-SNAPSHOT.
I also noticed some copyright notices were missing, so also added those.