### PR TITLE
Use the `SpanFactory` in the `SpringHttpCommandBusConnector`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
             ${project.basedir}/../coverage-report/target/site/jacoco-aggregate/jacoco.xml
         </sonar.coverage.jacoco.xmlReportPaths>
 
-        <axon.version>4.7.0</axon.version>
+        <axon.version>4.8.0</axon.version>
         <spring-cloud-release.version>2021.0.7</spring-cloud-release.version>
 
         <spring.version>5.3.28</spring.version>

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,7 @@
         <javax.jaxb-api.version>2.3.1</javax.jaxb-api.version>
         <guava-collections.version>r03</guava-collections.version>
         <junit.jupiter.version>5.9.1</junit.jupiter.version>
+        <findbugs-jsr305.version>3.0.2</findbugs-jsr305.version>
 
         <jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
     </properties>
@@ -189,6 +190,12 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-starter</artifactId>
                 <version>${spring.boot.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.google.code.findbugs</groupId>
+                <artifactId>jsr305</artifactId>
+                <version>${findbugs-jsr305.version}</version>
             </dependency>
 
             <dependency>

--- a/springcloud-spring-boot-autoconfigure/src/test/java/org/axonframework/extensions/springcloud/autoconfig/SpringCloudAutoConfigurationTest.java
+++ b/springcloud-spring-boot-autoconfigure/src/test/java/org/axonframework/extensions/springcloud/autoconfig/SpringCloudAutoConfigurationTest.java
@@ -32,7 +32,6 @@ import org.axonframework.extensions.springcloud.commandhandling.mode.MemberCapab
 import org.axonframework.extensions.springcloud.commandhandling.mode.RestCapabilityDiscoveryMode;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.*;
-import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.autoconfigure.jmx.JmxAutoConfiguration;
@@ -64,87 +63,90 @@ import static org.junit.jupiter.api.Assertions.*;
 @ExtendWith(SpringExtension.class)
 class SpringCloudAutoConfigurationTest {
 
-    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
-            .withConfiguration(AutoConfigurations.of(Context.class));
+    private ApplicationContextRunner testApplicationContext;
+
+    @BeforeEach
+    void setUp() {
+        testApplicationContext = new ApplicationContextRunner().withUserConfiguration(TestContext.class)
+                                                               .withPropertyValues("axon.axonserver.enabled=false");
+    }
 
     @Test
     void defaultSpringCloudAutoConfiguration() {
-        contextRunner.withPropertyValues("axon.axonserver.enabled=false")
-                     .run(context -> {
-                         assertThat(context).getBeanNames(RoutingStrategy.class)
-                                            .isEmpty();
-                         assertThat(context).getBeanNames(RestTemplate.class)
-                                            .isEmpty();
-                         assertThat(context).getBeanNames(CapabilityDiscoveryMode.class)
-                                            .isEmpty();
-                         assertThat(context).getBeanNames(CommandRouter.class)
-                                            .isEmpty();
-                         assertThat(context).getBeanNames(CommandBusConnector.class)
-                                            .isEmpty();
+        testApplicationContext.run(context -> {
+            assertThat(context).getBeanNames(RoutingStrategy.class)
+                               .isEmpty();
+            assertThat(context).getBeanNames(RestTemplate.class)
+                               .isEmpty();
+            assertThat(context).getBeanNames(CapabilityDiscoveryMode.class)
+                               .isEmpty();
+            assertThat(context).getBeanNames(CommandRouter.class)
+                               .isEmpty();
+            assertThat(context).getBeanNames(CommandBusConnector.class)
+                               .isEmpty();
 
-                         assertThat(context).getBeanNames(CommandBus.class)
-                                            .hasSize(1);
-                         assertThat(context).getBean(CommandBus.class)
-                                            .isExactlyInstanceOf(SimpleCommandBus.class);
-                     });
+            assertThat(context).getBeanNames(CommandBus.class)
+                               .hasSize(1);
+            assertThat(context).getBean(CommandBus.class)
+                               .isExactlyInstanceOf(SimpleCommandBus.class);
+        });
     }
 
     @Test
     void enabledSpringCloudAutoConfiguration() {
-        contextRunner.withPropertyValues("axon.distributed.enabled=true", "axon.axonserver.enabled=false")
-                     .run(context -> {
-                         assertThat(context).getBeanNames(RoutingStrategy.class)
-                                            .hasSize(1);
-                         assertThat(context).getBean(RoutingStrategy.class)
-                                            .isExactlyInstanceOf(AnnotationRoutingStrategy.class);
+        testApplicationContext.withPropertyValues("axon.distributed.enabled=true").run(context -> {
+            assertThat(context).getBeanNames(RoutingStrategy.class)
+                               .hasSize(1);
+            assertThat(context).getBean(RoutingStrategy.class)
+                               .isExactlyInstanceOf(AnnotationRoutingStrategy.class);
 
-                         assertThat(context).getBeanNames(RestTemplate.class)
-                                            .hasSize(1);
-                         assertThat(context).getBean(RestTemplate.class)
-                                            .isExactlyInstanceOf(RestTemplate.class);
+            assertThat(context).getBeanNames(RestTemplate.class)
+                               .hasSize(1);
+            assertThat(context).getBean(RestTemplate.class)
+                               .isExactlyInstanceOf(RestTemplate.class);
 
-                         assertThat(context).getBeanNames(RestCapabilityDiscoveryMode.class)
-                                            .hasSize(1);
-                         assertThat(context).getBeanNames(CapabilityDiscoveryMode.class)
-                                            .hasSize(2);
-                         assertThat(context).getBean(CapabilityDiscoveryMode.class)
-                                            .isExactlyInstanceOf(IgnoreListingDiscoveryMode.class);
-                         assertThat(context).getBean("restCapabilityDiscoveryMode", CapabilityDiscoveryMode.class)
-                                            .isExactlyInstanceOf(RestCapabilityDiscoveryMode.class);
+            assertThat(context).getBeanNames(RestCapabilityDiscoveryMode.class)
+                               .hasSize(1);
+            assertThat(context).getBeanNames(CapabilityDiscoveryMode.class)
+                               .hasSize(2);
+            assertThat(context).getBean(CapabilityDiscoveryMode.class)
+                               .isExactlyInstanceOf(IgnoreListingDiscoveryMode.class);
+            assertThat(context).getBean("restCapabilityDiscoveryMode",
+                                        CapabilityDiscoveryMode.class)
+                               .isExactlyInstanceOf(RestCapabilityDiscoveryMode.class);
 
-                         assertThat(context).getBeanNames(MemberCapabilitiesController.class)
-                                            .hasSize(1);
-                         assertThat(context).getBean(MemberCapabilitiesController.class)
-                                            .isExactlyInstanceOf(MemberCapabilitiesController.class);
+            assertThat(context).getBeanNames(MemberCapabilitiesController.class)
+                               .hasSize(1);
+            assertThat(context).getBean(MemberCapabilitiesController.class)
+                               .isExactlyInstanceOf(MemberCapabilitiesController.class);
 
-                         assertThat(context).getBeanNames(CommandRouter.class)
-                                            .hasSize(1);
-                         assertThat(context).getBean(CommandRouter.class)
-                                            .isExactlyInstanceOf(SpringCloudCommandRouter.class);
+            assertThat(context).getBeanNames(CommandRouter.class)
+                               .hasSize(1);
+            assertThat(context).getBean(CommandRouter.class)
+                               .isExactlyInstanceOf(SpringCloudCommandRouter.class);
 
-                         assertThat(context).getBeanNames(CommandBusConnector.class)
-                                            .hasSize(1);
-                         assertThat(context).getBean(CommandBusConnector.class)
-                                            .isExactlyInstanceOf(SpringHttpCommandBusConnector.class);
+            assertThat(context).getBeanNames(CommandBusConnector.class)
+                               .hasSize(1);
+            assertThat(context).getBean(CommandBusConnector.class)
+                               .isExactlyInstanceOf(SpringHttpCommandBusConnector.class);
 
-                         assertThat(context).getBeanNames(CommandBus.class)
-                                            .hasSize(2);
+            assertThat(context).getBeanNames(CommandBus.class)
+                               .hasSize(2);
 
-                         Map<String, CommandBus> commandBuses = context.getBeansOfType(CommandBus.class);
-                         CommandBus localSegment = commandBuses.get("commandBus");
-                         assertEquals(SimpleCommandBus.class, localSegment.getClass());
-                         CommandBus distributedCommandBus = commandBuses.get("distributedCommandBus");
-                         assertEquals(DistributedCommandBus.class, distributedCommandBus.getClass());
-                         assertNotEquals(localSegment, distributedCommandBus);
-                     });
+            Map<String, CommandBus> commandBuses = context.getBeansOfType(CommandBus.class);
+            CommandBus localSegment = commandBuses.get("commandBus");
+            assertEquals(SimpleCommandBus.class, localSegment.getClass());
+            CommandBus distributedCommandBus = commandBuses.get("distributedCommandBus");
+            assertEquals(DistributedCommandBus.class, distributedCommandBus.getClass());
+            assertNotEquals(localSegment, distributedCommandBus);
+        });
     }
 
     @Test
     void disablingIgnoreListingOnlyCreatesRestCapabilityDiscoveryMode() {
-        contextRunner.withPropertyValues(
+        testApplicationContext.withPropertyValues(
                 "axon.distributed.enabled=true",
-                "axon.distributed.spring-cloud.enable-ignore-listing=false",
-                "axon.axonserver.enabled=false"
+                "axon.distributed.spring-cloud.enable-ignore-listing=false"
         ).run(context -> {
             assertThat(context).getBeanNames(CapabilityDiscoveryMode.class)
                                .hasSize(1);
@@ -155,11 +157,10 @@ class SpringCloudAutoConfigurationTest {
 
     @Test
     void disablingIgnoreListingAndAcceptAllOnlyCreatesRestCapabilityDiscoveryMode() {
-        contextRunner.withPropertyValues(
+        testApplicationContext.withPropertyValues(
                 "axon.distributed.enabled=true",
                 "axon.distributed.spring-cloud.enable-ignore-listing=false",
-                "axon.distributed.spring-cloud.enable-accept-all-commands=false",
-                "axon.axonserver.enabled=false"
+                "axon.distributed.spring-cloud.enable-accept-all-commands=false"
         ).run(context -> {
             assertThat(context).getBeanNames(CapabilityDiscoveryMode.class)
                                .hasSize(1);
@@ -170,11 +171,10 @@ class SpringCloudAutoConfigurationTest {
 
     @Test
     void enablingIgnoreListingCreatesTwoCapabilityDiscoveryModeInstances() {
-        contextRunner.withPropertyValues(
+        testApplicationContext.withPropertyValues(
                 "axon.distributed.enabled=true",
                 "axon.distributed.spring-cloud.enable-ignore-listing=true",
-                "axon.distributed.spring-cloud.enable-accept-all-commands=false",
-                "axon.axonserver.enabled=false"
+                "axon.distributed.spring-cloud.enable-accept-all-commands=false"
         ).run(context -> {
             assertThat(context).getBeanNames(CapabilityDiscoveryMode.class)
                                .hasSize(2);
@@ -187,11 +187,10 @@ class SpringCloudAutoConfigurationTest {
 
     @Test
     void enablingAcceptAllCreatesTwoCapabilityDiscoveryModeInstances() {
-        contextRunner.withPropertyValues(
+        testApplicationContext.withPropertyValues(
                 "axon.distributed.enabled=true",
                 "axon.distributed.spring-cloud.enable-ignore-listing=false",
-                "axon.distributed.spring-cloud.enable-accept-all-commands=true",
-                "axon.axonserver.enabled=false"
+                "axon.distributed.spring-cloud.enable-accept-all-commands=true"
         ).run(context -> {
             assertThat(context).getBeanNames(CapabilityDiscoveryMode.class)
                                .hasSize(2);
@@ -204,11 +203,10 @@ class SpringCloudAutoConfigurationTest {
 
     @Test
     void enablingIgnoreListingAndAcceptAllCreatesTwoCapabilityDiscoveryModeInstances() {
-        contextRunner.withPropertyValues(
+        testApplicationContext.withPropertyValues(
                 "axon.distributed.enabled=true",
                 "axon.distributed.spring-cloud.enable-ignore-listing=True",
-                "axon.distributed.spring-cloud.enable-accept-all-commands=true",
-                "axon.axonserver.enabled=false"
+                "axon.distributed.spring-cloud.enable-accept-all-commands=true"
         ).run(context -> {
             assertThat(context).getBeanNames(CapabilityDiscoveryMode.class)
                                .hasSize(2);
@@ -233,7 +231,7 @@ class SpringCloudAutoConfigurationTest {
             HibernateJpaAutoConfiguration.class,
             DataSourceAutoConfiguration.class
     })
-    public static class Context {
+    public static class TestContext {
 
         @Bean
         public DiscoveryClient discoveryClient() {

--- a/springcloud/pom.xml
+++ b/springcloud/pom.xml
@@ -72,6 +72,11 @@
             <version>${jackson.version}</version>
             <optional>true</optional>
         </dependency>
+
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+        </dependency>
         <!-- Testing -->
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/springcloud/pom.xml
+++ b/springcloud/pom.xml
@@ -72,18 +72,24 @@
             <version>${jackson.version}</version>
             <optional>true</optional>
         </dependency>
-
+        <!-- Testing -->
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
             <version>${jackson.version}</version>
             <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava-collections</artifactId>
             <version>${guava-collections.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.axonframework</groupId>
+            <artifactId>axon-messaging</artifactId>
+            <version>${axon.version}</version>
+            <type>test-jar</type>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/springcloud/src/main/java/org/axonframework/extensions/springcloud/commandhandling/SpringHttpCommandBusConnector.java
+++ b/springcloud/src/main/java/org/axonframework/extensions/springcloud/commandhandling/SpringHttpCommandBusConnector.java
@@ -53,6 +53,8 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
+import javax.annotation.Nonnull;
+
 import static org.axonframework.commandhandling.GenericCommandResultMessage.asCommandResultMessage;
 import static org.axonframework.common.BuilderUtils.assertNonNull;
 
@@ -125,7 +127,7 @@ public class SpringHttpCommandBusConnector implements CommandBusConnector {
     }
 
     @Override
-    public <C> void send(Member destination, CommandMessage<? extends C> commandMessage) {
+    public <C> void send(Member destination, @Nonnull CommandMessage<? extends C> commandMessage) {
         shutdownLatch.ifShuttingDown("JGroupsConnector is shutting down, no new commands will be sent.");
         if (destination.local()) {
             localCommandBus.dispatch(commandMessage);
@@ -136,9 +138,10 @@ public class SpringHttpCommandBusConnector implements CommandBusConnector {
 
     @Override
     public <C, R> void send(Member destination,
-                            CommandMessage<C> commandMessage,
-                            CommandCallback<? super C, R> callback) {
+                            @Nonnull CommandMessage<C> commandMessage,
+                            @Nonnull CommandCallback<? super C, R> callback) {
         shutdownLatch.ifShuttingDown("SpringHttpCommandBusConnector is shutting down, no new commands will be sent.");
+        //noinspection resource
         ShutdownLatch.ActivityHandle activityHandle = shutdownLatch.registerActivity();
         if (destination.local()) {
             CommandCallback<C, R> wrapper = (cm, crm) -> {
@@ -220,7 +223,8 @@ public class SpringHttpCommandBusConnector implements CommandBusConnector {
     }
 
     @Override
-    public Registration subscribe(String commandName, MessageHandler<? super CommandMessage<?>> handler) {
+    public Registration subscribe(@Nonnull String commandName,
+                                  @Nonnull MessageHandler<? super CommandMessage<?>> handler) {
         return localCommandBus.subscribe(commandName, handler);
     }
 
@@ -267,7 +271,7 @@ public class SpringHttpCommandBusConnector implements CommandBusConnector {
 
     @Override
     public Registration registerHandlerInterceptor(
-            MessageHandlerInterceptor<? super CommandMessage<?>> handlerInterceptor
+            @Nonnull MessageHandlerInterceptor<? super CommandMessage<?>> handlerInterceptor
     ) {
         return localCommandBus.registerHandlerInterceptor(handlerInterceptor);
     }
@@ -277,8 +281,8 @@ public class SpringHttpCommandBusConnector implements CommandBusConnector {
 
         @Override
         public void onResult(CommandMessage<? extends C> commandMessage,
-                             CommandResultMessage<? extends R> commandResultMessage) {
-            super.complete(createReply(commandMessage, commandResultMessage));
+                             @Nonnull CommandResultMessage<? extends R> commandResultMessage) {
+            super.complete(createReply(commandMessage.getIdentifier(), commandResultMessage));
         }
     }
 


### PR DESCRIPTION
This pull request adds the `SpanFactory` to the `SpringHttpCommandBusConnector`.
The `SpanFactory` is used on the `SpringHttpCommandBusConnector#receiveCommand` operation to set the child span upon receiving a command.

In doing so, this pull request resolves #231.