### PR TITLE
[#327] Default local `ServiceInstance` to a fixed `URI` i.o. `null`

### DIFF
--- a/springcloud/src/main/java/org/axonframework/extensions/springcloud/commandhandling/mode/AbstractCapabilityDiscoveryMode.java
+++ b/springcloud/src/main/java/org/axonframework/extensions/springcloud/commandhandling/mode/AbstractCapabilityDiscoveryMode.java
@@ -79,6 +79,14 @@ public abstract class AbstractCapabilityDiscoveryMode<B extends CapabilityDiscov
         protected abstract void validate();
     }
 
+    /**
+     * This no-op version of the {@link DefaultServiceInstance} enforces the {@link ServiceInstance#getUri()} to a fixed
+     * empty {@link URI}. Through this, there's always a {@code ServiceInstance} present that will never match others.
+     * <p>
+     * This no-op version is the default local {@code ServiceInstance}, ensuring that when
+     * {@link #updateLocalCapabilities(ServiceInstance, int, CommandMessageFilter)} is never invoked (when an instance
+     * has zero command handlers) it will still play nicely in the discovery mechanism.
+     */
     private static class NoopUriServiceInstance extends DefaultServiceInstance {
 
         private static final ServiceInstance INSTANCE = new NoopUriServiceInstance();

--- a/springcloud/src/main/java/org/axonframework/extensions/springcloud/commandhandling/mode/AbstractCapabilityDiscoveryMode.java
+++ b/springcloud/src/main/java/org/axonframework/extensions/springcloud/commandhandling/mode/AbstractCapabilityDiscoveryMode.java
@@ -18,8 +18,10 @@ package org.axonframework.extensions.springcloud.commandhandling.mode;
 
 import org.axonframework.commandhandling.distributed.CommandMessageFilter;
 import org.axonframework.common.AxonConfigurationException;
+import org.springframework.cloud.client.DefaultServiceInstance;
 import org.springframework.cloud.client.ServiceInstance;
 
+import java.net.URI;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -42,7 +44,7 @@ public abstract class AbstractCapabilityDiscoveryMode<B extends CapabilityDiscov
      */
     protected AbstractCapabilityDiscoveryMode(Builder<B> builder) {
         builder.validate();
-        localInstance = new AtomicReference<>();
+        localInstance = new AtomicReference<>(NoopUriServiceInstance.INSTANCE);
         localCapabilities = new AtomicReference<>(DefaultMemberCapabilities.INCAPABLE_MEMBER);
     }
 
@@ -75,5 +77,16 @@ public abstract class AbstractCapabilityDiscoveryMode<B extends CapabilityDiscov
          *                                    specifications
          */
         protected abstract void validate();
+    }
+
+    private static class NoopUriServiceInstance extends DefaultServiceInstance {
+
+        private static final ServiceInstance INSTANCE = new NoopUriServiceInstance();
+        private static final URI FIXED_URI = URI.create("");
+
+        @Override
+        public URI getUri() {
+            return FIXED_URI;
+        }
     }
 }

--- a/springcloud/src/main/java/org/axonframework/extensions/springcloud/commandhandling/mode/AbstractCapabilityDiscoveryMode.java
+++ b/springcloud/src/main/java/org/axonframework/extensions/springcloud/commandhandling/mode/AbstractCapabilityDiscoveryMode.java
@@ -44,7 +44,7 @@ public abstract class AbstractCapabilityDiscoveryMode<B extends CapabilityDiscov
      */
     protected AbstractCapabilityDiscoveryMode(Builder<B> builder) {
         builder.validate();
-        localInstance = new AtomicReference<>(NoopUriServiceInstance.INSTANCE);
+        localInstance = new AtomicReference<>(FixedURIServiceInstance.INSTANCE);
         localCapabilities = new AtomicReference<>(DefaultMemberCapabilities.INCAPABLE_MEMBER);
     }
 
@@ -87,9 +87,9 @@ public abstract class AbstractCapabilityDiscoveryMode<B extends CapabilityDiscov
      * {@link #updateLocalCapabilities(ServiceInstance, int, CommandMessageFilter)} is never invoked (when an instance
      * has zero command handlers) it will still play nicely in the discovery mechanism.
      */
-    private static class NoopUriServiceInstance extends DefaultServiceInstance {
+    private static class FixedURIServiceInstance extends DefaultServiceInstance {
 
-        private static final ServiceInstance INSTANCE = new NoopUriServiceInstance();
+        private static final ServiceInstance INSTANCE = new FixedURIServiceInstance();
         private static final URI FIXED_URI = URI.create("");
 
         @Override

--- a/springcloud/src/test/java/org/axonframework/extensions/springcloud/commandhandling/mode/RestCapabilityDiscoveryModeTest.java
+++ b/springcloud/src/test/java/org/axonframework/extensions/springcloud/commandhandling/mode/RestCapabilityDiscoveryModeTest.java
@@ -122,7 +122,6 @@ class RestCapabilityDiscoveryModeTest {
     @Test
     void testCapabilitiesGetsCapabilitiesThroughRestTemplate() {
         MemberCapabilities expectedCapabilities = new DefaultMemberCapabilities(LOAD_FACTOR, COMMAND_MESSAGE_FILTER);
-        testSubject.updateLocalCapabilities(localInstance, LOAD_FACTOR, COMMAND_MESSAGE_FILTER);
 
         URI testURI = URI.create("http://remote");
         ServiceInstance testServiceInstance = mock(ServiceInstance.class);

--- a/springcloud/src/test/java/org/axonframework/extensions/springcloud/commandhandling/mode/RestCapabilityDiscoveryModeTest.java
+++ b/springcloud/src/test/java/org/axonframework/extensions/springcloud/commandhandling/mode/RestCapabilityDiscoveryModeTest.java
@@ -66,7 +66,7 @@ class RestCapabilityDiscoveryModeTest {
     }
 
     @Test
-    void testGetLocalMemberCapabilitiesReturnsIncapableMemberIfLocalCapabilitiesIsNeverUpdated() {
+    void getLocalMemberCapabilitiesReturnsIncapableMemberIfLocalCapabilitiesIsNeverUpdated() {
         SerializedMemberCapabilities result = ((RestCapabilityDiscoveryMode) testSubject).getLocalMemberCapabilities();
 
         DefaultMemberCapabilities deserializableResult =
@@ -76,7 +76,7 @@ class RestCapabilityDiscoveryModeTest {
     }
 
     @Test
-    void testGetLocalMemberCapabilitiesReturnsUpdatedLocalCapabilities() {
+    void getLocalMemberCapabilitiesReturnsUpdatedLocalCapabilities() {
         testSubject.updateLocalCapabilities(localInstance, LOAD_FACTOR, COMMAND_MESSAGE_FILTER);
 
         SerializedMemberCapabilities result = ((RestCapabilityDiscoveryMode) testSubject).getLocalMemberCapabilities();
@@ -88,7 +88,7 @@ class RestCapabilityDiscoveryModeTest {
     }
 
     @Test
-    void testCapabilitiesReturnsLocalCapabilitiesIfLocalServiceInstanceIsUsed() {
+    void capabilitiesReturnsLocalCapabilitiesIfLocalServiceInstanceIsUsed() {
         testSubject.updateLocalCapabilities(localInstance, LOAD_FACTOR, COMMAND_MESSAGE_FILTER);
 
         Optional<MemberCapabilities> resultCapabilities = testSubject.capabilities(localInstance);
@@ -101,7 +101,7 @@ class RestCapabilityDiscoveryModeTest {
     }
 
     @Test
-    void testCapabilitiesReturnsLocalCapabilitiesIfServiceInstanceUriMatches() {
+    void capabilitiesReturnsLocalCapabilitiesIfServiceInstanceUriMatches() {
         URI testURI = URI.create("http://remote");
         when(localInstance.getUri()).thenReturn(testURI);
 
@@ -120,7 +120,7 @@ class RestCapabilityDiscoveryModeTest {
     }
 
     @Test
-    void testCapabilitiesGetsCapabilitiesThroughRestTemplate() {
+    void capabilitiesGetsCapabilitiesThroughRestTemplate() {
         MemberCapabilities expectedCapabilities = new DefaultMemberCapabilities(LOAD_FACTOR, COMMAND_MESSAGE_FILTER);
 
         URI testURI = URI.create("http://remote");
@@ -157,7 +157,7 @@ class RestCapabilityDiscoveryModeTest {
     }
 
     @Test
-    void testCapabilitiesRethrowsHttpClientErrorExceptionAsServiceInstanceClientException() {
+    void capabilitiesRethrowsHttpClientErrorExceptionAsServiceInstanceClientException() {
         testSubject.updateLocalCapabilities(localInstance, LOAD_FACTOR, COMMAND_MESSAGE_FILTER);
 
         when(restTemplate.exchange(
@@ -181,7 +181,7 @@ class RestCapabilityDiscoveryModeTest {
     }
 
     @Test
-    void testCapabilitiesReturnsIncapableMemberWhenNonHttpClientErrorExceptionIsThrown() {
+    void capabilitiesReturnsIncapableMemberWhenNonHttpClientErrorExceptionIsThrown() {
         testSubject.updateLocalCapabilities(localInstance, LOAD_FACTOR, COMMAND_MESSAGE_FILTER);
 
         when(restTemplate.exchange(


### PR DESCRIPTION
This pull request defaults the `ServiceInstance` of the `AbstractCapabilityDiscoveryMode` to a private `ServiceInstance` with a fixed `URI`.

Doing so, we prevent a scenario when the `CapabilityDiscoveryMode#updateLocalCapabilities` is **never** invoked, leading to a `null` `ServiceInstance`.
Preventing this scenario ensures that Axon Framework instances that have **zero** command handlers will not fail on the "is this the local node I am asking capabilities for"-check, when retrieving the capabilities of other instances.

This pull request resolves #327