### PR TITLE
Remove `}` from `RestCapabilityDiscoverMode` constant

### DIFF
--- a/springcloud/src/main/java/org/axonframework/extensions/springcloud/commandhandling/mode/RestCapabilityDiscoveryMode.java
+++ b/springcloud/src/main/java/org/axonframework/extensions/springcloud/commandhandling/mode/RestCapabilityDiscoveryMode.java
@@ -147,7 +147,7 @@ public class RestCapabilityDiscoveryMode extends AbstractCapabilityDiscoveryMode
 
         private Supplier<Serializer> serializerSupplier = XStreamSerializer::defaultSerializer;
         private RestTemplate restTemplate;
-        private String messageCapabilitiesEndpoint = "/member-capabilities}";
+        private String messageCapabilitiesEndpoint = "/member-capabilities";
 
         /**
          * Sets the {@link Serializer} used to de-/serialize the {@link CommandMessageFilter}. Defaults to the {@link


### PR DESCRIPTION
The member-capabilities constant contains an extra } which causes a problem if one creates the RestCapabilityDiscoverMode using the builder manually.