### PR TITLE
Move old docs to library

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ For more information on anything Axon, please visit our website, [http://axoniq.
 
 ## Getting started
 
-The [reference guide](https://docs.axoniq.io) contains a separate chapter for all the extensions.
-The Spring Cloud extension description can be found [here](https://docs.axoniq.io/reference-guide/extensions/spring-cloud).
+The [AxonIQ Library](https://library.axoniq.io) contains a section for the guides of all the Axon Framework extensions.
+The Spring Cloud extension guide can be found [here](https://library.axoniq.io/home/guides/axon-framework.html).
 
 ## Receiving help
 
@@ -34,10 +34,10 @@ Are you having trouble using the extension?
 We'd like to help you out the best we can!
 There are a couple of things to consider when you're traversing anything Axon:
 
-* Checking the [reference guide](https://docs.axoniq.io/reference-guide/extensions/spring-cloud) should be your first stop,
- as the majority of possible scenarios you might encounter when using Axon should be covered there.
+* Checking the [reference guide](https://library.axoniq.io/axon_framework_old_ref/) should be your first stop,
+  as the majority of possible scenarios you might encounter when using Axon should be covered there.
 * If the Reference Guide does not cover a specific topic you would've expected,
- we'd appreciate if you could file an [issue](https://github.com/AxonIQ/reference-guide/issues) about it for us. 
+  we'd appreciate if you could post a [new thread/topic on our library fourms describing the problem](https://discuss.axoniq.io/c/26).
 * There is a [forum](https://discuss.axoniq.io/) to support you in the case the reference guide did not sufficiently answer your question.
 Axon Framework and Server developers will help out on a best effort basis.
 Know that any support from contributors on posted question is very much appreciated on the forum.

--- a/docs/_playbook/.gitignore
+++ b/docs/_playbook/.gitignore
@@ -1,0 +1,5 @@
+build
+node_modules
+.vscode
+vale
+package-lock.json

--- a/docs/_playbook/.vale.ini
+++ b/docs/_playbook/.vale.ini
@@ -1,0 +1,24 @@
+StylesPath = vale
+
+MinAlertLevel = suggestion
+
+Packages = http://github.com/AxonIQ/axoniq-vale-package/releases/latest/download/axoniq-vale-package.zip
+
+Vocab = general, AxonIQ, Java, Names_Terms, misc
+
+[*.{adoc,html}]
+BasedOnStyles = AxonIQ, proselint, Google
+
+Google.Headings = NO # Diasable in favor od AxonIQ one
+Google.Parens = NO # Disable warning about using parens
+Google.Quotes = NO # Diasable "commas and periods go inside quotation marks"
+Google.WordList = NO # Disable Google's word list
+Google.Passive = NO # Allow the use of Passive voice
+Google.Colons = NO # Allow the use of Colons
+Google.Will = NO # Allow use will
+Google.Contractions = NO
+Google.We = NO
+
+
+AxonIQ.AcronymCase = NO
+AxonIQ.HeadingTitle = NO

--- a/docs/_playbook/.vale.ini
+++ b/docs/_playbook/.vale.ini
@@ -20,5 +20,4 @@ Google.Contractions = NO
 Google.We = NO
 
 
-AxonIQ.AcronymCase = NO
-AxonIQ.HeadingTitle = NO
+

--- a/docs/_playbook/package.json
+++ b/docs/_playbook/package.json
@@ -1,0 +1,11 @@
+{
+  "devDependencies": {
+    "@antora/atlas-extension": "^1.0.0-alpha.2",
+    "@antora/cli": "^3.2.0-alpha.2",
+    "@antora/lunr-extension": "^1.0.0-alpha.8",
+    "@antora/site-generator": "^3.2.0-alpha.2",
+    "@asciidoctor/tabs": "^1.0.0-beta.6",
+    "@axoniq/antora-vale-extension": "^0.1.1",
+    "asciidoctor-kroki": "^0.17.0"
+  }
+}

--- a/docs/_playbook/playbook.yaml
+++ b/docs/_playbook/playbook.yaml
@@ -1,0 +1,42 @@
+site:
+  title: Spring Cloud Extension docs PREVIEW
+  start_page: springcloud_extension_guide::index.adoc
+
+content:
+  sources:
+  - url: ../..
+    start_paths: ['docs/*', '!docs/_*']
+
+asciidoc:
+  attributes:
+    experimental: true
+    page-pagination: true
+    kroki-fetch-diagram: true
+  #   primary-site-manifest-url: https://library.axoniq.io/site-manifest.json
+  extensions:
+    - asciidoctor-kroki
+    - '@asciidoctor/tabs'
+
+antora:
+  extensions:
+    - id: prose-linting
+      require: '@axoniq/antora-vale-extension'
+      enabled: true
+      vale_config: .vale.ini
+      update_styles: true
+    - id: lunr
+      require: '@antora/lunr-extension'
+      enabled: true
+      index_latest_only: true
+    - id: atlas
+      require: '@antora/atlas-extension'
+
+runtime:
+  fetch: true # fetch remote repos
+  log:
+    level: info
+    failure_level: error
+
+ui:
+  bundle:
+    url: https://github.com/AxonIQ/axoniq-library-ui/releases/download/v.0.1.10/ui-bundle.zip

--- a/docs/extension-guide/antora.yml
+++ b/docs/extension-guide/antora.yml
@@ -1,0 +1,14 @@
+name: springcloud_extension_guide
+title: Spring Cloud Extension Guide
+version: true
+prerelease: true
+start_page: ROOT:index.adoc
+
+asciidoc:
+  attributes:
+    component_description: The Spring Cloud Extension guide from the former reference guide
+    type: guide
+    group: axon-framework
+
+nav:
+  - modules/nav.adoc

--- a/docs/extension-guide/modules/ROOT/pages/command-routes.adoc
+++ b/docs/extension-guide/modules/ROOT/pages/command-routes.adoc
@@ -1,0 +1,37 @@
+:navtitle: Discovering Command Routes
+= Discovering Command Routes
+
+The `SpringCloudCommandRouter` uses Spring Cloud's discovery mechanism to find the other nodes in the cluster. To that end it uses the `DiscoveryClient` and `Registration` from Spring Cloud. These are respectively used to gather remote command routing information and maintain local information. The most straightforward way to retrieve both is by annotating your application with `@EnableDiscoveryClient`.
+
+Gathering and storing the command routing information revolves around Spring Cloud's `ServiceInstances`. A `Registration` is just the local `ServiceInstance`, whereas the `DiscoveryClient` provides the API to find remote `ServiceInstances`. Furthermore, it is the `ServiceInstance` which provides us with the required information (for example, the URI) to retrieve a node's capabilities.
+
+[NOTE]
+.Spring Cloud's Heartbeat Requirement
+====
+When using the `SpringCloudCommandRouter`, make sure your Spring application has heartbeat events enabled. The heartbeat events published by a Spring Cloud application are the trigger to check if the set of `ServiceInstances` from the `DiscoveryClient` has been changed. Additionally, it is used to validate whether the command routing capabilities for known nodes has been altered.
+
+Thus, if heartbeat events are disabled, your instance will no longer be updated with the current command routing capabilities. If so, this will cause issues during command routing.
+====
+
+The logic to store the local capabilities and discovering the remote capabilities of a `ServiceInstance` is maintained in the `CapabilityDiscoveryMode`. It is thus the `CapabilityDiscoveryMode` which provides us the means to actually retrieve a `ServiceInstance` 's set of commands it can handle (if any). The sole full implementation provided of the `CapabilityDiscoveryMode`, is the `RestCapabilityDiscoveryMode`, using a `RestTemplate` and the `ServiceInstance` URI to invoke a configurable endpoint. This endpoint leads to the `MemberCapabilitiesController` which in turn exposes the `MemberCapabilities` on the `RestCapabilityDiscoveryMode` of that instance.
+
+There are decorators present for the `CapabilityDiscoveryMode`, providing two additional features:
+
+
+. `IgnoreListingDiscoveryMode` - a `CapabilityDiscoveryMode` decorator which on failure of retrieving the `MemberCapabilities` will place the given `ServiceInstance` on a list to be ignored for future validation. It thus effectively removes discoverable `ServiceInstances` from the set.
+
+. `AcceptAllCommandsDiscoveryMode` - a `CapabilityDiscoveryMode` decorator which regardless of what this instance can handle as commands, state it can handle anything. This decorator comes in handy if the nodes in the system are homogeneous (aka, everybody can handle the same set of commands).
+
+The `Registration`, `DiscoveryClient` and `CapabilityDiscoveryMode` are arguably the heart of the `SpringCloudCommandRouter`. There are, however, a couple of additional things you can configure for this router, which are the following:
+
+- `RoutingStrategy` - The component in charge of deciding which of the nodes receives the commands consistently. By default, a `AnnotationRoutingStrategy` is used (see xref:axon_framework_old_ref:axon-framework-commands:infrastructure.adoc#DistributedCommandBus[Distributing the Command Bus] for more).
+
+- A `ServiceInstance` filter - This `Predicate` is used to filter out `ServiceInstance` retrieved through the `DiscoveryClient`. For example, it allows the removal of instances which are known to not handle any command messages. This might be useful if you have several services within the Spring Cloud Discovery Service set up, which you do not ever want to take into account for command handling.
+
+- `ConsistentHashChangeListener` - Adding a consistent hash change listener provides you with the opportunity to perform a specific task if new nodes have been added to the known command handlers set.
+
+[NOTE]
+.Differing Command Capabilities per Node
+====
+It is not required for all nodes to have the same set of command handlers. You may use different segments for different command types altogether. The Distributed Command Bus will always choose a node to dispatch a command to the one that has support for that specific type of command.
+====

--- a/docs/extension-guide/modules/ROOT/pages/config.adoc
+++ b/docs/extension-guide/modules/ROOT/pages/config.adoc
@@ -1,0 +1,95 @@
+:navtitle: Configuring This Extension
+= Configuring This Extension
+
+Chances are high that you will be using Spring Boot if you are also using Spring Cloud. As configuring goes, this would opt for usage of the `axon-springcloud-spring-boot-starter` dependency to automatically retrieve all required beans. In either case, your application should be marked to enable it as a discoverable service through Spring Cloud. This can, for example, be done by annotating the main class with `@EnableDiscoveryClient`.
+
+There are still quite a few customizable components. For some suggestions, take a look at the following examples:
+
+[tabs]
+======
+Custom Bean Configuration::
++
+[source,java]
+----
+// Custom Spring Boot app, enabling a 'DiscoveryClient' and 'Registration' through `@EnableDiscoveryClient`
+@EnableDiscoveryClient
+@SpringBootApplication
+public class MyApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(MyApplication.class, args);
+    }
+
+    @Bean
+    public CapabilityDiscoveryMode capabilityDiscoveryMode(RestTemplate restTemplate, Serializer serializer) {
+        return RestCapabilityDiscoveryMode.builder()
+                                          .restTemplate(restTemplate)
+                                          .serializer(serializer)
+                                          // Allows changing the endpoint used to find member capabilities
+                                          .messageCapabilitiesEndpoint(/* custom message information endpoint */)
+                                          .build();
+    }
+
+    @Bean
+    public CommandRouter springCloudCommandRouter(DiscoveryClient discoveryClient,
+                                                  Registration localServiceInstance,
+                                                  CapabilityDiscoveryMode capabilityDiscoveryMode) {
+        return SpringCloudCommandRouter.builder()
+                                       .discoveryClient(discoveryClient)
+                                       .routingStrategy(new AnnotationRoutingStrategy())
+                                       .localServiceInstance(localServiceInstance)
+                                       .capabilityDiscoveryMode(capabilityDiscoveryMode)
+                                       .serviceInstanceFilter(/* custom ServiceInstance filter */)
+                                       .consistentHashChangeListener(/* ConsistentHash change listener */)
+                                       .build();
+    }
+
+    // Only required if Axon Spring Boot Starter is not used
+    @Bean
+    @Qualifier("localSegment")
+    public CommandBus localSegment() {
+        return SimpleCommandBus.builder().build();
+    }
+
+    @Bean
+    public CommandBusConnector springHttpCommandBusConnector(@Qualifier("localSegment") CommandBus localSegment,
+                                                             RestOperations restOperations,
+                                                             Serializer serializer) {
+        return SpringHttpCommandBusConnector.builder()
+                                            .localCommandBus(localSegment)
+                                            .restOperations(restOperations)
+                                            .serializer(serializer)
+                                            .executor(/* custom Executor */)
+                                            .build();
+    }
+
+    @Bean
+    @Primary
+    public DistributedCommandBus distributedCommandBus(CommandRouter commandRouter,
+                                                       CommandBusConnector commandBusConnector) {
+        return DistributedCommandBus.builder()
+                                    .commandRouter(commandRouter)
+                                    .connector(commandBusConnector)
+                                    .build();
+    }
+}
+----
+
+Spring Boot AutoConfiguration::
++
+[source,properties]
+----
+# Required to enabled the DistributedCommandBus
+axon.distributed.enabled=true
+# Defines the load factor used for this segment. Defaults to 100
+axon.distributed.load-factor=100
+# Defines the CapabilityDiscoveryMode used. Defaults to REST
+axon.distributed.spring-cloud.mode=rest
+# Defines the endpoint used to retrieve member capabilities from. Defaults to "/member-capabilities"
+axon.distributed.spring-cloud.rest-mode-url="/my-custom-endpoint"
+# Defines whether the CapabilityDiscoveryMode should be decorated to ignore faulty ServiceInstances
+axon.distributed.spring-cloud.enable-ignore-listing=true
+# Defines whether the CapabilityDiscoveryMode should be decorated to accept all types of commands
+axon.distributed.spring-cloud.enable-accept-all-commands=true
+----
+======

--- a/docs/extension-guide/modules/ROOT/pages/index.adoc
+++ b/docs/extension-guide/modules/ROOT/pages/index.adoc
@@ -1,0 +1,12 @@
+:navtitle: Spring Cloud Extension
+= Spring Cloud
+
+Spring Cloud is an alternative approach to distributing the command bus (commands), besides Axon Server as the default.
+
+The Spring Cloud Extension uses the service registration and discovery mechanism described by link:https://spring.io/projects/spring-cloud[Spring Cloud,window=_blank,role=external] for distributing the command bus. You thus have the choice of which Spring Cloud implementation to use when discovering the routes to distribute your commands. An example of that would be Netflix' link:https://cloud.spring.io/spring-cloud-netflix/multi/multi__service_discovery_eureka_clients.html[Eureka Discovery/Eureka Server,window=_blank,role=external] combination or HashiCorp's link:https://www.consul.io/use-cases/service-discovery-and-health-checking[Consul,window=_blank,role=external].
+
+To use the Spring Cloud components from Axon, make sure the `axon-springcloud` module is available on the classpath. The easiest way is to include the Spring Cloud starter (`axon-springcloud-spring-boot-starter`) from this extension to your project.
+
+Giving a description of every Spring Cloud implementation would push this reference guide too far. For information on other Spring Cloud implementation options out there, please refer to their respective documentations.
+
+The Spring Cloud connector setup is a combination of the `SpringCloudCommandRouter` and a `SpringHttpCommandBusConnector`. The former is the `CommandRouter` and latter the `CommandBusConnector`, both used by the `DistributedCommandBus` to enable command distribution.

--- a/docs/extension-guide/modules/ROOT/pages/internode-commands.adoc
+++ b/docs/extension-guide/modules/ROOT/pages/internode-commands.adoc
@@ -1,0 +1,20 @@
+:navtitle: Sending Commands between Nodes
+= Sending Commands between Nodes
+
+The `CommandBusConnector` is in charge of sending commands, based on a given route, from one node to another. This extension to that end provides the `SpringHttpCommandBusConnector`, which uses plain REST for sending commands.
+
+There are three hard requirements when creating this service and one optional configuration:
+
+. Local `CommandBus` - This "local segment" is the command bus which dispatches commands into the local JVM. It is thus invoked when the `SpringHttpCommandBusConnector` receives a command from the outside, or if it receives a command which is meant for itself.
+
+. `RestOperations` - The service used to POST a command message to another instance. In most situations the `RestTemplate` is used for this.
+
+. `Serializer` - The serializer is used to serialize the command messages before they are sent over and deserialize when they are received.
+
+. `Executor` (optional) - The `Executor` is used to handle incoming commands and to dispatch commands. Defaults to a `DirectExecutor` instance for backwards compatibility.
+
+[NOTE]
+.Non-blocking command dispatching
+====
+Note that the configurable `Executor` impacts how command dispatching acts when invoking `CommandGateway#send` methods returning a `CompletableFuture`. Although the `CompletableFuture` return type suggests a non-blocking result, if the bus under the hood reuses the dispatching thread we are still faced with a blocking operation. Hence, to make the `SpringHttpCommandBusConnector` fully non-blocking, it is recommended to adjust the Executor to use its own thread pool.
+====

--- a/docs/extension-guide/modules/nav.adoc
+++ b/docs/extension-guide/modules/nav.adoc
@@ -1,0 +1,4 @@
+* xref::index.adoc[]
+** xref::command-routes.adoc[]
+** xref::internode-commands.adoc[]
+** xref::config.adoc[]


### PR DESCRIPTION
Move contents from the Extension section for Spring Cloud in the old reference guide to this repo so that antora can publish the extension-guide at library.axoniq.io